### PR TITLE
RH2023467: Enable FIPS keys export

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
+++ b/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
@@ -65,10 +65,13 @@ public final class SunRsaSignEntries {
             attrs.put("SupportedKeyClasses",
                     "java.security.interfaces.RSAPublicKey" +
                     "|java.security.interfaces.RSAPrivateKey");
+        }
 
-            add(p, "KeyFactory", "RSA",
-                    "sun.security.rsa.RSAKeyFactory$Legacy",
-                    getAliases("PKCS1"), null);
+        add(p, "KeyFactory", "RSA",
+                "sun.security.rsa.RSAKeyFactory$Legacy",
+                getAliases("PKCS1"), null);
+
+        if (!systemFipsEnabled) {
             add(p, "KeyPairGenerator", "RSA",
                     "sun.security.rsa.RSAKeyPairGenerator$Legacy",
                     getAliases("PKCS1"), null);
@@ -98,9 +101,12 @@ public final class SunRsaSignEntries {
                    "sun.security.rsa.RSASignature$SHA3_384withRSA", attrs);
             addA(p, "Signature", "SHA3-512withRSA",
                     "sun.security.rsa.RSASignature$SHA3_512withRSA", attrs);
+        }
 
-            addA(p, "KeyFactory", "RSASSA-PSS",
-                    "sun.security.rsa.RSAKeyFactory$PSS", attrs);
+        addA(p, "KeyFactory", "RSASSA-PSS",
+                "sun.security.rsa.RSAKeyFactory$PSS", attrs);
+
+        if (!systemFipsEnabled) {
             addA(p, "KeyPairGenerator", "RSASSA-PSS",
                     "sun.security.rsa.RSAKeyPairGenerator$PSS", attrs);
             addA(p, "Signature", "RSASSA-PSS",

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -37,6 +37,8 @@ import javax.crypto.*;
 import javax.crypto.interfaces.*;
 import javax.crypto.spec.*;
 
+import jdk.internal.access.SharedSecrets;
+
 import sun.security.rsa.RSAUtil.KeyType;
 import sun.security.rsa.RSAPublicKeyImpl;
 import sun.security.rsa.RSAPrivateCrtKeyImpl;
@@ -68,6 +70,9 @@ import sun.security.jca.JCAUtil;
  * @since   1.5
  */
 abstract class P11Key implements Key, Length {
+
+    private static final boolean plainKeySupportEnabled = SharedSecrets
+            .getJavaSecuritySystemConfiguratorAccess().isPlainKeySupportEnabled();
 
     private static final long serialVersionUID = -2575874101938349339L;
 
@@ -461,7 +466,8 @@ abstract class P11Key implements Key, Length {
         }
         public String getFormat() {
             token.ensureValid();
-            if (sensitive || (extractable == false)) {
+            if (!plainKeySupportEnabled &&
+                    (sensitive || (extractable == false))) {
                 return null;
             } else {
                 return "RAW";

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -384,7 +384,8 @@ abstract class P11Key implements Key, Length {
             new CK_ATTRIBUTE(CKA_SENSITIVE),
             new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
+        if (!plainKeySupportEnabled && (attributes[1].getBoolean() ||
+                (attributes[2].getBoolean() == false))) {
             return new P11PrivateKey
                 (session, keyID, algorithm, keyLength, attributes);
         } else {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -73,20 +73,28 @@ public final class SunPKCS11 extends AuthProvider {
             .getJavaSecuritySystemConfiguratorAccess().isPlainKeySupportEnabled();
 
     private static final MethodHandle fipsImportKey;
+    private static final MethodHandle fipsExportKey;
     static {
         MethodHandle fipsImportKeyTmp = null;
+        MethodHandle fipsExportKeyTmp = null;
         if (plainKeySupportEnabled) {
             try {
                 fipsImportKeyTmp = MethodHandles.lookup().findStatic(
                         FIPSKeyImporter.class, "importKey",
                         MethodType.methodType(Long.class, SunPKCS11.class,
                         long.class, CK_ATTRIBUTE[].class));
+                fipsExportKeyTmp = MethodHandles.lookup().findStatic(
+                        FIPSKeyImporter.class, "exportKey",
+                        MethodType.methodType(void.class, SunPKCS11.class,
+                        long.class, long.class, long.class,
+                        CK_ATTRIBUTE[].class));
             } catch (Throwable t) {
-                throw new SecurityException("FIPS key importer initialization" +
-                        " failed", t);
+                throw new SecurityException("FIPS key importer-exporter" +
+                        " initialization failed", t);
             }
         }
         fipsImportKey = fipsImportKeyTmp;
+        fipsExportKey = fipsExportKeyTmp;
     }
 
     private static final long serialVersionUID = -1354835039035306505L;
@@ -348,14 +356,18 @@ public final class SunPKCS11 extends AuthProvider {
             initArgs.flags = CKF_OS_LOCKING_OK;
             PKCS11 tmpPKCS11;
             MethodHandle fipsKeyImporter = null;
+            MethodHandle fipsKeyExporter = null;
             if (plainKeySupportEnabled) {
                 fipsKeyImporter = MethodHandles.insertArguments(
                         fipsImportKey, 0, this);
+                fipsKeyExporter = MethodHandles.insertArguments(
+                        fipsExportKey, 0, this);
             }
             try {
                 tmpPKCS11 = PKCS11.getInstance(
                     library, functionList, initArgs,
-                    config.getOmitInitialize(), fipsKeyImporter);
+                    config.getOmitInitialize(), fipsKeyImporter,
+                    fipsKeyExporter);
             } catch (PKCS11Exception e) {
                 if (debug != null) {
                     debug.println("Multi-threaded initialization failed: " + e);
@@ -371,7 +383,8 @@ public final class SunPKCS11 extends AuthProvider {
                     initArgs.flags = 0;
                 }
                 tmpPKCS11 = PKCS11.getInstance(library,
-                    functionList, initArgs, config.getOmitInitialize(), fipsKeyImporter);
+                    functionList, initArgs, config.getOmitInitialize(), fipsKeyImporter,
+                    fipsKeyExporter);
             }
             p11 = tmpPKCS11;
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -86,8 +86,8 @@ public final class SunPKCS11 extends AuthProvider {
                 fipsExportKeyTmp = MethodHandles.lookup().findStatic(
                         FIPSKeyImporter.class, "exportKey",
                         MethodType.methodType(void.class, SunPKCS11.class,
-                        long.class, long.class, long.class,
-                        CK_ATTRIBUTE[].class));
+                        long.class, long.class,
+                        long.class, long.class, Map.class));
             } catch (Throwable t) {
                 throw new SecurityException("FIPS key importer-exporter" +
                         " initialization failed", t);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -50,6 +50,8 @@ package sun.security.pkcs11.wrapper;
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.*;
 
 import java.security.AccessController;
@@ -153,25 +155,27 @@ public class PKCS11 {
 
     public static synchronized PKCS11 getInstance(String pkcs11ModulePath,
             String functionList, CK_C_INITIALIZE_ARGS pInitArgs,
-            boolean omitInitialize, MethodHandle fipsKeyImporter)
+            boolean omitInitialize, MethodHandle fipsKeyImporter,
+            MethodHandle fipsKeyExporter)
                     throws IOException, PKCS11Exception {
         // we may only call C_Initialize once per native .so/.dll
         // so keep a cache using the (non-canonicalized!) path
         PKCS11 pkcs11 = moduleMap.get(pkcs11ModulePath);
         if (pkcs11 == null) {
-            boolean nssFipsMode = fipsKeyImporter != null;
+            boolean nssFipsMode = fipsKeyImporter != null &&
+                    fipsKeyExporter != null;
             if ((pInitArgs != null)
                     && ((pInitArgs.flags & CKF_OS_LOCKING_OK) != 0)) {
                 if (nssFipsMode) {
                     pkcs11 = new FIPSPKCS11(pkcs11ModulePath, functionList,
-                            fipsKeyImporter);
+                            fipsKeyImporter, fipsKeyExporter);
                 } else {
                     pkcs11 = new PKCS11(pkcs11ModulePath, functionList);
                 }
             } else {
                 if (nssFipsMode) {
                     pkcs11 = new SynchronizedFIPSPKCS11(pkcs11ModulePath,
-                            functionList, fipsKeyImporter);
+                            functionList, fipsKeyImporter, fipsKeyExporter);
                 } else {
                     pkcs11 = new SynchronizedPKCS11(pkcs11ModulePath, functionList);
                 }
@@ -1930,13 +1934,29 @@ static class SynchronizedPKCS11 extends PKCS11 {
 // is enabled.
 static class FIPSPKCS11 extends PKCS11 {
     private MethodHandle fipsKeyImporter;
+    private MethodHandle fipsKeyExporter;
+    private MethodHandle hC_GetAttributeValue;
     FIPSPKCS11(String pkcs11ModulePath, String functionListName,
-            MethodHandle fipsKeyImporter) throws IOException {
+            MethodHandle fipsKeyImporter, MethodHandle fipsKeyExporter)
+                    throws IOException {
         super(pkcs11ModulePath, functionListName);
         this.fipsKeyImporter = fipsKeyImporter;
+        this.fipsKeyExporter = fipsKeyExporter;
+        try {
+            hC_GetAttributeValue = MethodHandles.insertArguments(
+                    MethodHandles.lookup().findSpecial(PKCS11.class,
+                            "C_GetAttributeValue", MethodType.methodType(
+                                    void.class, long.class, long.class,
+                                    CK_ATTRIBUTE[].class),
+                            FIPSPKCS11.class), 0, this);
+        } catch (Throwable t) {
+            throw new RuntimeException(
+                    "sun.security.pkcs11.wrapper.PKCS11" +
+                    "::C_GetAttributeValue method not found.", t);
+        }
     }
 
-    public synchronized long C_CreateObject(long hSession,
+    public long C_CreateObject(long hSession,
             CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
         // Creating sensitive key objects from plain key material in a
         // FIPS-configured NSS Software Token is not allowed. We apply
@@ -1946,20 +1966,46 @@ static class FIPSPKCS11 extends PKCS11 {
                 return ((Long)fipsKeyImporter.invoke(hSession, pTemplate))
                         .longValue();
             } catch (Throwable t) {
-                throw new PKCS11Exception(CKR_GENERAL_ERROR);
+                if (t instanceof PKCS11Exception) {
+                    throw (PKCS11Exception)t;
+                }
+                throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                        t.getMessage());
             }
         }
         return super.C_CreateObject(hSession, pTemplate);
+    }
+
+    public void C_GetAttributeValue(long hSession, long hObject,
+            CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+        FIPSPKCS11Helper.C_GetAttributeValue(hC_GetAttributeValue,
+                fipsKeyExporter, hSession, hObject, pTemplate);
     }
 }
 
 // FIPSPKCS11 synchronized counterpart.
 static class SynchronizedFIPSPKCS11 extends SynchronizedPKCS11 {
     private MethodHandle fipsKeyImporter;
+    private MethodHandle fipsKeyExporter;
+    private MethodHandle hC_GetAttributeValue;
     SynchronizedFIPSPKCS11(String pkcs11ModulePath, String functionListName,
-            MethodHandle fipsKeyImporter) throws IOException {
+            MethodHandle fipsKeyImporter, MethodHandle fipsKeyExporter)
+                    throws IOException {
         super(pkcs11ModulePath, functionListName);
         this.fipsKeyImporter = fipsKeyImporter;
+        this.fipsKeyExporter = fipsKeyExporter;
+        try {
+            hC_GetAttributeValue = MethodHandles.insertArguments(
+                    MethodHandles.lookup().findSpecial(SynchronizedPKCS11.class,
+                            "C_GetAttributeValue", MethodType.methodType(
+                                    void.class, long.class, long.class,
+                                    CK_ATTRIBUTE[].class),
+                            SynchronizedFIPSPKCS11.class), 0, this);
+        } catch (Throwable t) {
+            throw new RuntimeException(
+                    "sun.security.pkcs11.wrapper.SynchronizedPKCS11" +
+                    "::C_GetAttributeValue method not found.", t);
+        }
     }
 
     public synchronized long C_CreateObject(long hSession,
@@ -1970,10 +2016,20 @@ static class SynchronizedFIPSPKCS11 extends SynchronizedPKCS11 {
                 return ((Long)fipsKeyImporter.invoke(hSession, pTemplate))
                         .longValue();
             } catch (Throwable t) {
-                throw new PKCS11Exception(CKR_GENERAL_ERROR);
+                if (t instanceof PKCS11Exception) {
+                    throw (PKCS11Exception)t;
+                }
+                throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                        t.getMessage());
             }
         }
         return super.C_CreateObject(hSession, pTemplate);
+    }
+
+    public synchronized void C_GetAttributeValue(long hSession, long hObject,
+            CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+        FIPSPKCS11Helper.C_GetAttributeValue(hC_GetAttributeValue,
+                fipsKeyExporter, hSession, hObject, pTemplate);
     }
 }
 
@@ -1987,6 +2043,71 @@ private static class FIPSPKCS11Helper {
             }
         }
         return false;
+    }
+    static void C_GetAttributeValue(MethodHandle hC_GetAttributeValue,
+            MethodHandle fipsKeyExporter, long hSession, long hObject,
+            CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
+        Map<Long, CK_ATTRIBUTE> sensitiveAttrs = new HashMap<>();
+        List<CK_ATTRIBUTE> nonSensitiveAttrs = new LinkedList<>();
+        FIPSPKCS11Helper.getAttributesBySensitivity(pTemplate,
+                sensitiveAttrs, nonSensitiveAttrs);
+        try {
+            if (sensitiveAttrs.size() > 0) {
+                CK_ATTRIBUTE[] keyClsAttrs = new CK_ATTRIBUTE[] {
+                        new CK_ATTRIBUTE(CKA_CLASS)
+                };
+                hC_GetAttributeValue.invoke(hSession, hObject, keyClsAttrs);
+                long keyClass = keyClsAttrs[0].getLong();
+                if (keyClass == CKO_SECRET_KEY) {
+                    // If the key is a secret key, we can extract the
+                    // CKA_VALUE attribute with the FIPS Key Exporter.
+                    if (!sensitiveAttrs.containsKey(CKA_VALUE) ||
+                            sensitiveAttrs.size() > 1) {
+                        throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                                " cannot get attribute values from" +
+                                " a CKO_SECRET_KEY key object");
+                    }
+                    CK_ATTRIBUTE[] keyValueAttrs = new CK_ATTRIBUTE[] {
+                            sensitiveAttrs.get(CKA_VALUE)
+                    };
+                    fipsKeyExporter.invoke(hSession, hObject, keyClass,
+                            keyValueAttrs);
+                    if (nonSensitiveAttrs.size() > 0) {
+                        CK_ATTRIBUTE[] pNonSensitiveAttrs =
+                                new CK_ATTRIBUTE[nonSensitiveAttrs.size()];
+                        int i = 0;
+                        for (CK_ATTRIBUTE nonSensitiveAttr : nonSensitiveAttrs) {
+                            pNonSensitiveAttrs[i++] = nonSensitiveAttr;
+                        }
+                        hC_GetAttributeValue.invoke(hSession, hObject,
+                                pNonSensitiveAttrs);
+                    }
+                    return;
+                }
+            }
+            hC_GetAttributeValue.invoke(hSession, hObject, pTemplate);
+        } catch (Throwable t) {
+            if (t instanceof PKCS11Exception) {
+                throw (PKCS11Exception)t;
+            }
+            throw new PKCS11Exception(CKR_GENERAL_ERROR,
+                    t.getMessage());
+        }
+    }
+    private static void getAttributesBySensitivity(CK_ATTRIBUTE[] pTemplate,
+            Map<Long, CK_ATTRIBUTE> sensitiveAttrs,
+            List<CK_ATTRIBUTE> nonSensitiveAttrs) {
+        for (CK_ATTRIBUTE attr : pTemplate) {
+            long type = attr.type;
+            if (type == CKA_VALUE || type == CKA_PRIVATE_EXPONENT ||
+                    type == CKA_PRIME_1 || type == CKA_PRIME_2 ||
+                    type == CKA_EXPONENT_1 || type == CKA_EXPONENT_2 ||
+                    type == CKA_COEFFICIENT) {
+                sensitiveAttrs.put(type, attr);
+            } else {
+                nonSensitiveAttrs.add(attr);
+            }
+        }
     }
 }
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Exception.java
@@ -220,14 +220,6 @@ public class PKCS11Exception extends Exception {
     }
 
     /**
-     * Constructor taking the error code (the CKR_* constants in PKCS#11) with
-     * no extra info for the error message.
-     */
-    public PKCS11Exception(long errorCode) {
-        this(errorCode, null);
-    }
-
-    /**
      * Constructor taking the error code (the CKR_* constants in PKCS#11) and
      * extra info for error message.
      */


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/1"))_

# [RH2023467: Enable the export of keys in plain from the NSS Software Token while in FIPS mode [rhel-8, openjdk-17]](https://bugzilla.redhat.com/show_bug.cgi?id=2023467)

## Description
In the context of [RH1991003](https://bugzilla.redhat.com/show_bug.cgi?id=1991003 "Enable the import of plain keys into the NSS Software Token while in FIPS mode"), we implemented an enhancement to import plain secret and private keys (i.e.: obtained from a file-based keystore) into the NSS Software token in FIPS mode. The goal now is to enable the reverse operation: export keys in plain from the NSS Software Token while in FIPS mode.

The scope was initially constrained to keys of `CKO_SECRET_KEY` class, as this is what we required for TLS 1.3 key-derivation in FIPS mode (see [RH2020290](https://bugzilla.redhat.com/show_bug.cgi?id=2020290 "Support TLS 1.3 in FIPS mode")). As a dependency for PKCS#12 keystores in FIPS mode (see [RH2048582](https://bugzilla.redhat.com/show_bug.cgi?id=2048582 "Support PKCS#12 keystores in FIPS mode")), we extended the exporter functionality to support keys of `CKO_PRIVATE_KEY` class, in colaboration with @martinuy, @akashche and myself (@franferrax).

In the same way that for the importer functionality, the exporter can be disabled by means of the `com.redhat.fips.plainKeySupport` system property: `-Dcom.redhat.fips.plainKeySupport=false`. Default behavior is enabled.

As part of this work, we aim to implement several code, debugging and reliability improvements to the FIPS Key Importer.