### PR TITLE
RH2094027: SunEC runtime permission for FIPS

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -119,6 +119,7 @@ grant codeBase "jrt:/jdk.charsets" {
 grant codeBase "jrt:/jdk.crypto.ec" {
     permission java.lang.RuntimePermission
                    "accessClassInPackage.sun.security.*";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.access";
     permission java.lang.RuntimePermission "loadLibrary.sunec";
     permission java.security.SecurityPermission "putProviderProperty.SunEC";
     permission java.security.SecurityPermission "clearProviderProperties.SunEC";


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/5"))_

Fix proposal for RH2094027 according to the bug description in its BZ [1].

--
[1] - https://bugzilla.redhat.com/show_bug.cgi?id=2094027