### PR TITLE
Build the systemconf library on all platforms

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -178,19 +178,17 @@ ifeq ($(USE_SYSCONF_NSS), true)
   LIBSYSTEMCONF_CXXFLAGS += $(NSS_CFLAGS) -DSYSCONF_NSS
 endif
 
-ifeq ($(OPENJDK_BUILD_OS), linux)
-  $(eval $(call SetupJdkLibrary, BUILD_LIBSYSTEMCONF, \
-      NAME := systemconf, \
-      OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKLIB) $(LIBSYSTEMCONF_CFLAGS), \
-      CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBSYSTEMCONF_CXXFLAGS), \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-          $(call SET_SHARED_LIBRARY_ORIGIN), \
-      LIBS_unix := $(LIBDL) $(NSS_LIBS), \
-  ))
+$(eval $(call SetupJdkLibrary, BUILD_LIBSYSTEMCONF, \
+    NAME := systemconf, \
+    OPTIMIZATION := LOW, \
+    CFLAGS := $(CFLAGS_JDKLIB) $(LIBSYSTEMCONF_CFLAGS), \
+    CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBSYSTEMCONF_CXXFLAGS), \
+    LDFLAGS := $(LDFLAGS_JDKLIB) \
+        $(call SET_SHARED_LIBRARY_ORIGIN), \
+    LIBS_unix := $(LIBDL) $(NSS_LIBS), \
+))
 
-  TARGETS += $(BUILD_LIBSYSTEMCONF)
-endif
+TARGETS += $(BUILD_LIBSYSTEMCONF)
 
 ################################################################################
 # Create the symbols file for static builds.

--- a/src/java.base/share/native/libsystemconf/systemconf.c
+++ b/src/java.base/share/native/libsystemconf/systemconf.c
@@ -28,6 +28,8 @@
 #include "jvm_md.h"
 #include <stdio.h>
 
+#ifdef LINUX
+
 #ifdef SYSCONF_NSS
 #include <nss3/pk11pub.h>
 #else
@@ -222,3 +224,13 @@ JNIEXPORT jboolean JNICALL Java_java_security_SystemConfigurator_getSystemFIPSEn
       return (fips_enabled == '1' ? JNI_TRUE : JNI_FALSE);
     }
 }
+
+#else // !LINUX
+
+JNIEXPORT jboolean JNICALL Java_java_security_SystemConfigurator_getSystemFIPSEnabled
+  (JNIEnv *env, jclass cls)
+{
+    return JNI_FALSE;
+}
+
+#endif


### PR DESCRIPTION
Currently, the makefile excludes building libsystemconf on any platform but Linux, but the JNI code in `SystemConfiguration.java` then unconditionally tries to load the library.

We could make this conditional on running on Linux, but we still have the problem of a native method in the class that doesn't resolve. The best solution seems to be to build the library, but provide a simple `JNI_FALSE` return for non-Linux systems. This also leaves the door open for an implementation on these platforms in future.