### PR TITLE
RH2036462: sun.security.pkcs11.wrapper.PKCS11.getInstance breakage

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -153,6 +153,17 @@ public class PKCS11 {
         this.pkcs11ModulePath = pkcs11ModulePath;
     }
 
+    /*
+     * Compatibility wrapper to allow this method to work as before
+     * when FIPS mode support is not active.
+     */
+    public static synchronized PKCS11 getInstance(String pkcs11ModulePath,
+           String functionList, CK_C_INITIALIZE_ARGS pInitArgs,
+           boolean omitInitialize) throws IOException, PKCS11Exception {
+        return getInstance(pkcs11ModulePath, functionList,
+                           pInitArgs, omitInitialize, null, null);
+    }
+
     public static synchronized PKCS11 getInstance(String pkcs11ModulePath,
             String functionList, CK_C_INITIALIZE_ARGS pInitArgs,
             boolean omitInitialize, MethodHandle fipsKeyImporter,


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/8"))_

This simple fix adds a wrapper method for `getInstance` so it can still be invoked using the upstream API, even with the FIPS code present. The FIPS additions already expect the importer and exporter values to be `null` when FIPS support mode is disabled, so there should be no issue with this method supplying those values as `null`.