### PR TITLE
Use encoded space rather than quoting for JTReg JAVA_OPTIONS

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -495,7 +495,7 @@ jobs:
           TEST="${{ matrix.suites }}"
           TEST_OPTS_JAVA_OPTIONS=
           JTREG_KEYWORDS="!headful"
-          JTREG="JAVA_OPTIONS='-Djava.security.debug=properties -XX:-CreateCoredumpOnCrash'"
+          JTREG="JAVA_OPTIONS=-Djava.security.debug=properties%20-XX:-CreateCoredumpOnCrash"
 
       - name: Check that all tests executed successfully
         if: always()


### PR DESCRIPTION
As mentioned in the [JTreg docs](https://github.com/openjdk/jdk17u/blob/jdk-17+35/doc/testing.md#test-suite-control) we can use an encoded space, `%20`, rather than trying to quote the options.