### PR TITLE
RH2020290: Support TLS 1.3 in FIPS mode

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -537,40 +537,22 @@ public abstract class SSLContextImpl extends SSLContextSpi {
         private static final List<CipherSuite> serverDefaultCipherSuites;
 
         static {
-            if (SharedSecrets.getJavaSecuritySystemConfiguratorAccess()
-                    .isSystemFipsEnabled()) {
-                // RH1860986: TLSv1.3 key derivation not supported with
-                // the Security Providers available in system FIPS mode.
-                supportedProtocols = Arrays.asList(
-                    ProtocolVersion.TLS12,
-                    ProtocolVersion.TLS11,
-                    ProtocolVersion.TLS10
-                );
+            supportedProtocols = Arrays.asList(
+                ProtocolVersion.TLS13,
+                ProtocolVersion.TLS12,
+                ProtocolVersion.TLS11,
+                ProtocolVersion.TLS10,
+                ProtocolVersion.SSL30,
+                ProtocolVersion.SSL20Hello
+            );
 
-                serverDefaultProtocols = getAvailableProtocols(
-                        new ProtocolVersion[] {
-                    ProtocolVersion.TLS12,
-                    ProtocolVersion.TLS11,
-                    ProtocolVersion.TLS10
-                });
-            } else {
-                supportedProtocols = Arrays.asList(
-                    ProtocolVersion.TLS13,
-                    ProtocolVersion.TLS12,
-                    ProtocolVersion.TLS11,
-                    ProtocolVersion.TLS10,
-                    ProtocolVersion.SSL30,
-                    ProtocolVersion.SSL20Hello
-                );
-
-                serverDefaultProtocols = getAvailableProtocols(
-                        new ProtocolVersion[] {
-                    ProtocolVersion.TLS13,
-                    ProtocolVersion.TLS12,
-                    ProtocolVersion.TLS11,
-                    ProtocolVersion.TLS10
-                });
-            }
+            serverDefaultProtocols = getAvailableProtocols(
+                    new ProtocolVersion[] {
+                ProtocolVersion.TLS13,
+                ProtocolVersion.TLS12,
+                ProtocolVersion.TLS11,
+                ProtocolVersion.TLS10
+            });
 
             supportedCipherSuites = getApplicableSupportedCipherSuites(
                     supportedProtocols);
@@ -861,23 +843,12 @@ public abstract class SSLContextImpl extends SSLContextSpi {
             ProtocolVersion[] candidates;
             if (refactored.isEmpty()) {
                 // Client and server use the same default protocols.
-                if (SharedSecrets.getJavaSecuritySystemConfiguratorAccess()
-                        .isSystemFipsEnabled()) {
-                    // RH1860986: TLSv1.3 key derivation not supported with
-                    // the Security Providers available in system FIPS mode.
-                    candidates = new ProtocolVersion[] {
-                            ProtocolVersion.TLS12,
-                            ProtocolVersion.TLS11,
-                            ProtocolVersion.TLS10
-                        };
-                } else {
-                    candidates = new ProtocolVersion[] {
-                            ProtocolVersion.TLS13,
-                            ProtocolVersion.TLS12,
-                            ProtocolVersion.TLS11,
-                            ProtocolVersion.TLS10
-                        };
-                }
+                candidates = new ProtocolVersion[] {
+                        ProtocolVersion.TLS13,
+                        ProtocolVersion.TLS12,
+                        ProtocolVersion.TLS11,
+                        ProtocolVersion.TLS10
+                    };
             } else {
                 // Use the customized TLS protocols.
                 candidates =

--- a/src/java.base/share/classes/sun/security/ssl/SunJSSE.java
+++ b/src/java.base/share/classes/sun/security/ssl/SunJSSE.java
@@ -27,8 +27,6 @@ package sun.security.ssl;
 
 import java.security.*;
 import java.util.*;
-
-import jdk.internal.access.SharedSecrets;
 import static sun.security.util.SecurityConstants.PROVIDER_VER;
 
 /**
@@ -104,13 +102,8 @@ public class SunJSSE extends java.security.Provider {
             "sun.security.ssl.SSLContextImpl$TLS11Context", null, null);
         ps("SSLContext", "TLSv1.2",
             "sun.security.ssl.SSLContextImpl$TLS12Context", null, null);
-        if (!SharedSecrets.getJavaSecuritySystemConfiguratorAccess()
-                .isSystemFipsEnabled()) {
-            // RH1860986: TLSv1.3 key derivation not supported with
-            // the Security Providers available in system FIPS mode.
-            ps("SSLContext", "TLSv1.3",
-                "sun.security.ssl.SSLContextImpl$TLS13Context", null, null);
-        }
+        ps("SSLContext", "TLSv1.3",
+            "sun.security.ssl.SSLContextImpl$TLS13Context", null, null);
         ps("SSLContext", "TLS",
             "sun.security.ssl.SSLContextImpl$TLSContext",
             List.of("SSL"), null);


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/13"))_

# [RH2020290: Support TLS 1.3 in FIPS mode [rhel-8, openjdk-17]](https://bugzilla.redhat.com/show_bug.cgi?id=2020290)

## Description
When _OpenJDK_ runs on a FIPS-configured system, TLS 1.3 (implemented in the _SunJSSE_ security provider) is disabled both on the server and client sides ([RH1860986](https://bugzilla.redhat.com/show_bug.cgi?id=1860986)). The reason is that the PKCS#11 key derivation mechanism for TLS 1.3 is not supported in the _SunPKCS11_ security provider; and the _SunJSSE_ code for key derivation would require to import plain secret keys into an _NSS Software Token_ (blocked by [RH1991003](https://bugzilla.redhat.com/show_bug.cgi?id=1991003)).

The goal of this task is to implement a solution to re-enable TLS 1.3 on both server and client sides when _OpenJDK_ runs in FIPS mode.