### PR TITLE
RH2104724: Avoid import/export of DH private keys

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
@@ -38,7 +38,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.SecretKeySpec;
-import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 
 import sun.security.jca.JCAUtil;
@@ -189,34 +188,6 @@ final class FIPSKeyImporter {
                             ECUtil.getECParameterSpec(sunECProvider,
                                     attrsMap.get(CKA_EC_PARAMS).getByteArray()))
                             .getEncoded();
-                    if (token.config.getNssNetscapeDbWorkaround() &&
-                            attrsMap.get(CKA_NETSCAPE_DB) == null) {
-                        attrsMap.put(CKA_NETSCAPE_DB,
-                                new CK_ATTRIBUTE(CKA_NETSCAPE_DB, BigInteger.ZERO));
-                    }
-                } else if (keyType == CKK_DH) {
-                    if (debug != null) {
-                        debug.println("Importing a Diffie-Hellman private key...");
-                    }
-                    if (DHKF == null) {
-                        DHKFLock.lock();
-                        try {
-                            if (DHKF == null) {
-                                DHKF = KeyFactory.getInstance(
-                                        "DH", P11Util.getSunJceProvider());
-                            }
-                        } finally {
-                            DHKFLock.unlock();
-                        }
-                    }
-                    DHPrivateKeySpec spec = new DHPrivateKeySpec
-                            (((v = attrsMap.get(CKA_VALUE).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO,
-                            ((v = attrsMap.get(CKA_PRIME).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO,
-                            ((v = attrsMap.get(CKA_BASE).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO);
-                    keyBytes = DHKF.generatePrivate(spec).getEncoded();
                     if (token.config.getNssNetscapeDbWorkaround() &&
                             attrsMap.get(CKA_NETSCAPE_DB) == null) {
                         attrsMap.put(CKA_NETSCAPE_DB,

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -384,7 +384,8 @@ abstract class P11Key implements Key, Length {
             new CK_ATTRIBUTE(CKA_SENSITIVE),
             new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        if (!plainKeySupportEnabled && (attributes[1].getBoolean() ||
+        boolean exportable = plainKeySupportEnabled && !algorithm.equals("DH");
+        if (!exportable && (attributes[1].getBoolean() ||
                 (attributes[2].getBoolean() == false))) {
             return new P11PrivateKey
                 (session, keyID, algorithm, keyLength, attributes);


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/14"))_

# [RH2104724](https://bugzilla.redhat.com/show_bug.cgi?id=2104724) / [RH2104725](https://bugzilla.redhat.com/show_bug.cgi?id=2104725): Avoid import/export of DH private keys

## Description
As [analyzed in OPENJDK-824](https://issues.redhat.com/browse/OPENJDK-824?focusedCommentId=20495041&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-20495041), NSS doesn't support wrapping/unwrapping of _Diffie-Hellman_ private keys (`CKK_DH`), so we can't import/export them from the _NSS PKCS#11 software token_.

In addition, as part of 78df8b5a8ba828ae5b459af6e1bf1ec91cae4608 work, we started to [blindly consider a private key extractable when the _plain key support_ is enabled](/rh-openjdk/jdk/commit/bd324bda437a924e58730cc67c133275e8203780#diff-8f7a3a78c41a81cc7d6198037c7cdaf5fc42d3536921d3751d8bbb681265dbe8R387-R388), preventing _DH_ private keys from being instantiated as the opaque `P11PrivateKey`. This now causes an error, as an attempt is made to extract these keys when instantiating the `P11DHPrivateKey` full-data object.

This work:
 1. Avoids the import/export of _DH_ private keys, going back to the opaque `P11PrivateKey` for them (instead of `P11DHPrivateKey`)
 2. Removes the useless code from the _FIPS key importer_ (abcd0954643eddbf826d96291d44a143038ab750), which hasn't triggered any issue, but it will never work
    * NOTE: the _FIPS key exporter_ doesn't have code to handle `CKK_DH` private keys.