### PR TITLE
RH2092507: P11Key.getEncoded does not work for DH keys in FIPS mode

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -540,86 +540,86 @@ public final class SunJCE extends Provider {
         psA("AlgorithmParameters", "ChaCha20-Poly1305",
                 "com.sun.crypto.provider.ChaCha20Poly1305Parameters", null);
 
+        /*
+         * Key factories
+         */
+        psA("KeyFactory", "DiffieHellman",
+                "com.sun.crypto.provider.DHKeyFactory",
+                null);
+
+        /*
+         * Secret-key factories
+         */
+        ps("SecretKeyFactory", "DES",
+                "com.sun.crypto.provider.DESKeyFactory");
+
+        psA("SecretKeyFactory", "DESede",
+                "com.sun.crypto.provider.DESedeKeyFactory", null);
+
+        psA("SecretKeyFactory", "PBEWithMD5AndDES",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndDES",
+                null);
+
+        /*
+         * Internal in-house crypto algorithm used for
+         * the JCEKS keystore type.  Since this was developed
+         * internally, there isn't an OID corresponding to this
+         * algorithm.
+         */
+        ps("SecretKeyFactory", "PBEWithMD5AndTripleDES",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndTripleDES");
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndDESede",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndDESede",
+                null);
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndRC2_40",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_40",
+                null);
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndRC2_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_128",
+                null);
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndRC4_40",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_40",
+                null);
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndRC4_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_128",
+                null);
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_256");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_256");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_256");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_256");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_256");
+
         if (!systemFipsEnabled) {
-            /*
-             * Key factories
-             */
-            psA("KeyFactory", "DiffieHellman",
-                    "com.sun.crypto.provider.DHKeyFactory",
-                    null);
-
-            /*
-             * Secret-key factories
-             */
-            ps("SecretKeyFactory", "DES",
-                    "com.sun.crypto.provider.DESKeyFactory");
-
-            psA("SecretKeyFactory", "DESede",
-                    "com.sun.crypto.provider.DESedeKeyFactory", null);
-
-            psA("SecretKeyFactory", "PBEWithMD5AndDES",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndDES",
-                    null);
-
-            /*
-             * Internal in-house crypto algorithm used for
-             * the JCEKS keystore type.  Since this was developed
-             * internally, there isn't an OID corresponding to this
-             * algorithm.
-             */
-            ps("SecretKeyFactory", "PBEWithMD5AndTripleDES",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndTripleDES");
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndDESede",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndDESede",
-                    null);
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndRC2_40",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_40",
-                    null);
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndRC2_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_128",
-                    null);
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndRC4_40",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_40",
-                    null);
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndRC4_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_128",
-                    null);
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_256");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_256");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_256");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_256");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_256");
-
             // PBKDF2
             psA("SecretKeyFactory", "PBKDF2WithHmacSHA1",
                     "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/16"))_

# [RH2092507](https://bugzilla.redhat.com/show_bug.cgi?id=2092507): P11Key.getEncoded does not work for DH keys in FIPS mode

## Description
This work fixes the `P11Key.getEncoded()` issue by enabling _SunJCE_'s secret key factories in FIPS mode (except for PBKDF2 secret key factories, which perform key derivation [\[&dagger;\]](#2e503e7578c3a8cea57436bb17276d33), a cryptographic operation that should only be handled by `SunPKCS11-NSS-FIPS`).

This issue was introduced in 6e74f283739af0d867df01d20f82865f559a45ea ([RH2052070](https://bugzilla.redhat.com/show_bug.cgi?id=2052070)), when a stripped/locked-down version of the _SunJCE_ provider was added to `java.security` in FIPS mode (by means of the `if (!systemFipsEnabled) { /* disabled code */ }` patching). _SunPKCS11_'s `P11Key.getEncoded()` internally uses _SunJCE_'s `KeyFactory` to encode Diffie-Hellman public keys despite _SunJCE_ not being listed in `java.security` [\[&ddagger;\]](#f6f14781e34f19f517d8b32d6be35741). Before 6e74f283739af0d867df01d20f82865f559a45ea, _SunJCE_ didn't need to be stripped/locked-down, so _SunPKCS11_ was directly using it unpatched, but now that it is listed in `java.security` (i.e. publicly available as a provider), the lock-down patching is mandatory. Consequently, we are just enabling _SunJCE_ key factories without cryptographic code, required by _SunPKCS11_ keys encoding (such as the `KeyFactory` for `"DiffieHellman"`/`"DH"`).

----
#### <a id="2e503e7578c3a8cea57436bb17276d33"></a>\[&dagger;\] See the following code:
https://github.com/rh-openjdk/jdk/blob/03b584eb4a2981eea0bd0660bcdeb7490c5bf6e0/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java#L623-L626
https://github.com/rh-openjdk/jdk/blob/03b584eb4a2981eea0bd0660bcdeb7490c5bf6e0/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2Core.java#L70
https://github.com/rh-openjdk/jdk/blob/03b584eb4a2981eea0bd0660bcdeb7490c5bf6e0/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java#L119

#### <a id="f6f14781e34f19f517d8b32d6be35741"></a>\[&ddagger;\]  See the following code:
https://github.com/rh-openjdk/jdk/blob/03b584eb4a2981eea0bd0660bcdeb7490c5bf6e0/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java#L167-L171
https://github.com/rh-openjdk/jdk/blob/03b584eb4a2981eea0bd0660bcdeb7490c5bf6e0/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java#L966-L967
https://github.com/rh-openjdk/jdk/blob/03b584eb4a2981eea0bd0660bcdeb7490c5bf6e0/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java#L71-L116