### PR TITLE
Forward-port recent changes from fips-17u

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -175,19 +175,17 @@ ifeq ($(USE_SYSCONF_NSS), true)
   LIBSYSTEMCONF_CXXFLAGS += $(NSS_CFLAGS) -DSYSCONF_NSS
 endif
 
-ifeq ($(OPENJDK_BUILD_OS), linux)
-  $(eval $(call SetupJdkLibrary, BUILD_LIBSYSTEMCONF, \
-      NAME := systemconf, \
-      OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKLIB) $(LIBSYSTEMCONF_CFLAGS), \
-      CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBSYSTEMCONF_CXXFLAGS), \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-          $(call SET_SHARED_LIBRARY_ORIGIN), \
-      LIBS_unix := $(LIBDL) $(NSS_LIBS), \
-  ))
+$(eval $(call SetupJdkLibrary, BUILD_LIBSYSTEMCONF, \
+    NAME := systemconf, \
+    OPTIMIZATION := LOW, \
+    CFLAGS := $(CFLAGS_JDKLIB) $(LIBSYSTEMCONF_CFLAGS), \
+    CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBSYSTEMCONF_CXXFLAGS), \
+    LDFLAGS := $(LDFLAGS_JDKLIB) \
+        $(call SET_SHARED_LIBRARY_ORIGIN), \
+    LIBS_unix := $(LIBDL) $(NSS_LIBS), \
+))
 
-  TARGETS += $(BUILD_LIBSYSTEMCONF)
-endif
+TARGETS += $(BUILD_LIBSYSTEMCONF)
 
 ################################################################################
 # Create the symbols file for static builds.

--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -540,86 +540,86 @@ public final class SunJCE extends Provider {
         psA("AlgorithmParameters", "ChaCha20-Poly1305",
                 "com.sun.crypto.provider.ChaCha20Poly1305Parameters", null);
 
+        /*
+         * Key factories
+         */
+        psA("KeyFactory", "DiffieHellman",
+                "com.sun.crypto.provider.DHKeyFactory",
+                null);
+
+        /*
+         * Secret-key factories
+         */
+        ps("SecretKeyFactory", "DES",
+                "com.sun.crypto.provider.DESKeyFactory");
+
+        psA("SecretKeyFactory", "DESede",
+                "com.sun.crypto.provider.DESedeKeyFactory", null);
+
+        psA("SecretKeyFactory", "PBEWithMD5AndDES",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndDES",
+                null);
+
+        /*
+         * Internal in-house crypto algorithm used for
+         * the JCEKS keystore type.  Since this was developed
+         * internally, there isn't an OID corresponding to this
+         * algorithm.
+         */
+        ps("SecretKeyFactory", "PBEWithMD5AndTripleDES",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndTripleDES");
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndDESede",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndDESede",
+                null);
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndRC2_40",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_40",
+                null);
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndRC2_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_128",
+                null);
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndRC4_40",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_40",
+                null);
+
+        psA("SecretKeyFactory", "PBEWithSHA1AndRC4_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_128",
+                null);
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_128",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_128");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_256");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_256");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_256");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_256");
+
+        ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_256",
+                "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_256");
+
         if (!systemFipsEnabled) {
-            /*
-             * Key factories
-             */
-            psA("KeyFactory", "DiffieHellman",
-                    "com.sun.crypto.provider.DHKeyFactory",
-                    null);
-
-            /*
-             * Secret-key factories
-             */
-            ps("SecretKeyFactory", "DES",
-                    "com.sun.crypto.provider.DESKeyFactory");
-
-            psA("SecretKeyFactory", "DESede",
-                    "com.sun.crypto.provider.DESedeKeyFactory", null);
-
-            psA("SecretKeyFactory", "PBEWithMD5AndDES",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndDES",
-                    null);
-
-            /*
-             * Internal in-house crypto algorithm used for
-             * the JCEKS keystore type.  Since this was developed
-             * internally, there isn't an OID corresponding to this
-             * algorithm.
-             */
-            ps("SecretKeyFactory", "PBEWithMD5AndTripleDES",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithMD5AndTripleDES");
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndDESede",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndDESede",
-                    null);
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndRC2_40",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_40",
-                    null);
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndRC2_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC2_128",
-                    null);
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndRC4_40",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_40",
-                    null);
-
-            psA("SecretKeyFactory", "PBEWithSHA1AndRC4_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithSHA1AndRC4_128",
-                    null);
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_128",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_128");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA1AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA1AndAES_256");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA224AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA224AndAES_256");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA256AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA256AndAES_256");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA384AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA384AndAES_256");
-
-            ps("SecretKeyFactory", "PBEWithHmacSHA512AndAES_256",
-                    "com.sun.crypto.provider.PBEKeyFactory$PBEWithHmacSHA512AndAES_256");
-
             // PBKDF2
             psA("SecretKeyFactory", "PBKDF2WithHmacSHA1",
                     "com.sun.crypto.provider.PBKDF2Core$HmacSHA1",

--- a/src/java.base/share/native/libsystemconf/systemconf.c
+++ b/src/java.base/share/native/libsystemconf/systemconf.c
@@ -28,6 +28,8 @@
 #include "jvm_md.h"
 #include <stdio.h>
 
+#ifdef LINUX
+
 #ifdef SYSCONF_NSS
 #include <nss3/pk11pub.h>
 #else
@@ -222,3 +224,13 @@ JNIEXPORT jboolean JNICALL Java_java_security_SystemConfigurator_getSystemFIPSEn
       return (fips_enabled == '1' ? JNI_TRUE : JNI_FALSE);
     }
 }
+
+#else // !LINUX
+
+JNIEXPORT jboolean JNICALL Java_java_security_SystemConfigurator_getSystemFIPSEnabled
+  (JNIEnv *env, jclass cls)
+{
+    return JNI_FALSE;
+}
+
+#endif

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
@@ -38,7 +38,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.SecretKeySpec;
-import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 
 import sun.security.jca.JCAUtil;
@@ -189,34 +188,6 @@ final class FIPSKeyImporter {
                             ECUtil.getECParameterSpec(sunECProvider,
                                     attrsMap.get(CKA_EC_PARAMS).getByteArray()))
                             .getEncoded();
-                    if (token.config.getNssNetscapeDbWorkaround() &&
-                            attrsMap.get(CKA_NETSCAPE_DB) == null) {
-                        attrsMap.put(CKA_NETSCAPE_DB,
-                                new CK_ATTRIBUTE(CKA_NETSCAPE_DB, BigInteger.ZERO));
-                    }
-                } else if (keyType == CKK_DH) {
-                    if (debug != null) {
-                        debug.println("Importing a Diffie-Hellman private key...");
-                    }
-                    if (DHKF == null) {
-                        DHKFLock.lock();
-                        try {
-                            if (DHKF == null) {
-                                DHKF = KeyFactory.getInstance(
-                                        "DH", P11Util.getSunJceProvider());
-                            }
-                        } finally {
-                            DHKFLock.unlock();
-                        }
-                    }
-                    DHPrivateKeySpec spec = new DHPrivateKeySpec
-                            (((v = attrsMap.get(CKA_VALUE).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO,
-                            ((v = attrsMap.get(CKA_PRIME).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO,
-                            ((v = attrsMap.get(CKA_BASE).getBigInteger()) != null)
-                                    ? v : BigInteger.ZERO);
-                    keyBytes = DHKF.generatePrivate(spec).getEncoded();
                     if (token.config.getNssNetscapeDbWorkaround() &&
                             attrsMap.get(CKA_NETSCAPE_DB) == null) {
                         attrsMap.put(CKA_NETSCAPE_DB,

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -401,7 +401,8 @@ abstract class P11Key implements Key, Length {
                     new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
 
-        boolean keySensitive = (!plainKeySupportEnabled &&
+        boolean exportable = plainKeySupportEnabled && !algorithm.equals("DH");
+        boolean keySensitive = (!exportable &&
             (attrs[0].getBoolean() ||
              attrs[1].getBoolean() || !attrs[2].getBoolean()));
 


### PR DESCRIPTION
* Build the systemconf library on all platforms (#7)
* RH2104724: Avoid import/export of DH private keys (#14)
* RH2092507: P11Key.getEncoded does not work for DH keys in FIPS mode (#16)
