### PR TITLE
RH2134669: Add missing attributes when registering services in FIPS mode.

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -183,13 +183,16 @@ public final class SunEntries {
                     "sun.security.provider.DSA$SHA3_384withDSAinP1363Format");
             add(p, "Signature", "SHA3-512withDSAinP1363Format",
                     "sun.security.provider.DSA$SHA3_512withDSAinP1363Format");
-            /*
-             *  Key Pair Generator engines
-             */
-            attrs.clear();
-            attrs.put("ImplementedIn", "Software");
-            attrs.put("KeySize", "2048"); // for DSA KPG and APG only
+        }
 
+        /*
+         *  Key Pair Generator engines
+         */
+        attrs.clear();
+        attrs.put("ImplementedIn", "Software");
+        attrs.put("KeySize", "2048"); // for DSA KPG and APG only
+
+        if (!systemFipsEnabled) {
             String dsaKPGImplClass = "sun.security.provider.DSAKeyPairGenerator$";
             dsaKPGImplClass += (useLegacyDSA? "Legacy" : "Current");
             addWithAlias(p, "KeyPairGenerator", "DSA", dsaKPGImplClass, attrs);

--- a/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
+++ b/src/java.base/share/classes/sun/security/rsa/SunRsaSignEntries.java
@@ -61,11 +61,9 @@ public final class SunRsaSignEntries {
         // start populating content using the specified provider
         // common attribute map
         HashMap<String, String> attrs = new HashMap<>(3);
-        if (!systemFipsEnabled) {
-            attrs.put("SupportedKeyClasses",
-                    "java.security.interfaces.RSAPublicKey" +
-                    "|java.security.interfaces.RSAPrivateKey");
-        }
+        attrs.put("SupportedKeyClasses",
+                "java.security.interfaces.RSAPublicKey" +
+                "|java.security.interfaces.RSAPrivateKey");
 
         add(p, "KeyFactory", "RSA",
                 "sun.security.rsa.RSAKeyFactory$Legacy",

--- a/test/jdk/sun/security/pkcs11/fips/VerifyMissingAttributes.java
+++ b/test/jdk/sun/security/pkcs11/fips/VerifyMissingAttributes.java
@@ -24,8 +24,6 @@
 
 import java.security.Provider;
 import java.security.Security;
-import java.util.HashMap;
-import java.util.Map;
 
 /*
  * @test
@@ -49,41 +47,31 @@ public final class VerifyMissingAttributes {
     };
 
     public static void main(String[] args) throws Throwable {
-        Map<String, String> attrs = new HashMap<>();
         Provider sunProvider = Security.getProvider("SUN");
         for (String svcAlg : svcAlgImplementedIn) {
-            attrs.clear();
-            attrs.put(svcAlg + " ImplementedIn", "Software");
-            doQuery(sunProvider, attrs);
+            String filter = svcAlg + " ImplementedIn:Software";
+            doQuery(sunProvider, filter);
         }
         if (Double.parseDouble(
                 System.getProperty("java.specification.version")) >= 17) {
-            attrs.clear();
-            attrs.put("KeyFactory.RSASSA-PSS SupportedKeyClasses",
+            String filter = "KeyFactory.RSASSA-PSS SupportedKeyClasses:" +
                     "java.security.interfaces.RSAPublicKey" +
-                            "|java.security.interfaces.RSAPrivateKey");
-            doQuery(Security.getProvider("SunRsaSign"), attrs);
+                    "|java.security.interfaces.RSAPrivateKey";
+            doQuery(Security.getProvider("SunRsaSign"), filter);
         }
         System.out.println("TEST PASS - OK");
     }
 
-    private static void doQuery(Provider expectedProvider,
-                Map<String, String> attrs) throws Exception {
+    private static void doQuery(Provider expectedProvider, String filter)
+            throws Exception {
         if (expectedProvider == null) {
             throw new Exception("Provider not found.");
         }
-        Provider[] providers = Security.getProviders(attrs);
+        Provider[] providers = Security.getProviders(filter);
         if (providers == null || providers.length != 1 ||
                 providers[0] != expectedProvider) {
-            StringBuffer sb = new StringBuffer();
-            attrs.entrySet().stream().forEach(ent -> {
-                sb.append(ent.getKey());
-                sb.append(": ");
-                sb.append(ent.getValue());
-                sb.append(System.lineSeparator());
-            });
             throw new Exception("Failure retrieving the provider with this" +
-                    " query: " + sb.toString());
+                    " query: " + filter);
         }
     }
 }

--- a/test/jdk/sun/security/pkcs11/fips/VerifyMissingAttributes.java
+++ b/test/jdk/sun/security/pkcs11/fips/VerifyMissingAttributes.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+ * @test
+ * @bug 9999999
+ * @requires (jdk.version.major >= 8)
+ * @run main/othervm/timeout=30 Main
+ * @author Martin Balao (mbalao@redhat.com)
+ */
+
+public final class VerifyMissingAttributes {
+
+    private static final String[] svcAlgImplementedIn = {
+            "AlgorithmParameterGenerator.DSA",
+            "AlgorithmParameters.DSA",
+            "CertificateFactory.X.509",
+            "KeyStore.JKS",
+            "KeyStore.CaseExactJKS",
+            "KeyStore.DKS",
+            "CertStore.Collection",
+            "CertStore.com.sun.security.IndexedCollection"
+    };
+
+    public static void main(String[] args) throws Throwable {
+        Map<String, String> attrs = new HashMap<>();
+        Provider sunProvider = Security.getProvider("SUN");
+        for (String svcAlg : svcAlgImplementedIn) {
+            attrs.clear();
+            attrs.put(svcAlg + " ImplementedIn", "Software");
+            doQuery(sunProvider, attrs);
+        }
+        if (Double.parseDouble(
+                System.getProperty("java.specification.version")) >= 17) {
+            attrs.clear();
+            attrs.put("KeyFactory.RSASSA-PSS SupportedKeyClasses",
+                    "java.security.interfaces.RSAPublicKey" +
+                            "|java.security.interfaces.RSAPrivateKey");
+            doQuery(Security.getProvider("SunRsaSign"), attrs);
+        }
+        System.out.println("TEST PASS - OK");
+    }
+
+    private static void doQuery(Provider expectedProvider,
+                Map<String, String> attrs) throws Exception {
+        if (expectedProvider == null) {
+            throw new Exception("Provider not found.");
+        }
+        Provider[] providers = Security.getProviders(attrs);
+        if (providers == null || providers.length != 1 ||
+                providers[0] != expectedProvider) {
+            StringBuffer sb = new StringBuffer();
+            attrs.entrySet().stream().forEach(ent -> {
+                sb.append(ent.getKey());
+                sb.append(": ");
+                sb.append(ent.getValue());
+                sb.append(System.lineSeparator());
+            });
+            throw new Exception("Failure retrieving the provider with this" +
+                    " query: " + sb.toString());
+        }
+    }
+}


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/19"))_

As described in RH2134669 [1], I'd like to propose a fix for this issue that keeps the attributes for registered services and algorithms aligned between FIPS and non-FIPS modes. According to my assessment, the only security providers affected by this issue were SUN (SunEntries.java) and SunRsaSign (SunRsaSignEntries.java).

--
[1] - https://bugzilla.redhat.com/show_bug.cgi?id=2134669