### PR TITLE
RH2130351: SunPKCS11 PBE API Enhancements

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES2Core.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES2Core.java
@@ -44,10 +44,6 @@ import sun.security.util.PBEUtil;
  * @see javax.crypto.Cipher
  */
 abstract class PBES2Core extends CipherSpi {
-
-    private static final int DEFAULT_SALT_LENGTH = 20;
-    private static final int DEFAULT_COUNT = 4096;
-
     // the encapsulated cipher
     private final CipherCore cipher;
     private final int keyLength; // in bits
@@ -55,8 +51,7 @@ abstract class PBES2Core extends CipherSpi {
     private final PBKDF2Core kdf;
     private final String pbeAlgo;
     private final String cipherAlgo;
-    private final PBEUtil.PBES2Helper pbes2Helper = new PBEUtil.PBES2Helper(
-            DEFAULT_SALT_LENGTH, DEFAULT_COUNT);
+    private final PBEUtil.PBES2Params pbes2Params = new PBEUtil.PBES2Params();
 
     /**
      * Creates an instance of PBE Scheme 2 according to the selected
@@ -129,7 +124,7 @@ abstract class PBES2Core extends CipherSpi {
     }
 
     protected AlgorithmParameters engineGetParameters() {
-        return pbes2Helper.getAlgorithmParameters(
+        return pbes2Params.getAlgorithmParameters(
                 blkSize, pbeAlgo, SunJCE.getInstance(), SunJCE.getRandom());
     }
 
@@ -150,7 +145,7 @@ abstract class PBES2Core extends CipherSpi {
                               SecureRandom random)
         throws InvalidKeyException, InvalidAlgorithmParameterException {
 
-        PBEKeySpec pbeSpec = pbes2Helper.getPBEKeySpec(blkSize, keyLength,
+        PBEKeySpec pbeSpec = pbes2Params.getPBEKeySpec(blkSize, keyLength,
                 opmode, key, params, random);
 
         PBKDF2KeyImpl s;
@@ -170,13 +165,13 @@ abstract class PBES2Core extends CipherSpi {
         SecretKeySpec cipherKey = new SecretKeySpec(derivedKey, cipherAlgo);
 
         // initialize the underlying cipher
-        cipher.init(opmode, cipherKey, pbes2Helper.getIvSpec(), random);
+        cipher.init(opmode, cipherKey, pbes2Params.getIvSpec(), random);
     }
 
     protected void engineInit(int opmode, Key key, AlgorithmParameters params,
                               SecureRandom random)
         throws InvalidKeyException, InvalidAlgorithmParameterException {
-        engineInit(opmode, key, PBEUtil.PBES2Helper.getParameterSpec(params),
+        engineInit(opmode, key, PBEUtil.PBES2Params.getParameterSpec(params),
                 random);
     }
 

--- a/src/java.base/share/classes/sun/security/util/PBEUtil.java
+++ b/src/java.base/share/classes/sun/security/util/PBEUtil.java
@@ -292,4 +292,26 @@ public final class PBEUtil {
             Arrays.fill(passwdChars, '\0');
         }
     }
+
+    public static AlgorithmParameterSpec checkKeyParams(Key key,
+            AlgorithmParameterSpec params, String algorithm)
+            throws InvalidKeyException, InvalidAlgorithmParameterException {
+        if (key instanceof javax.crypto.interfaces.PBEKey pbeKey) {
+            if (params instanceof PBEParameterSpec pbeParams) {
+                if (pbeParams.getIterationCount() !=
+                        pbeKey.getIterationCount() ||
+                        !Arrays.equals(pbeParams.getSalt(), pbeKey.getSalt())) {
+                    throw new InvalidAlgorithmParameterException(
+                            "Salt or iteration count parameters are " +
+                            "not consistent with PBE key");
+                }
+                return pbeParams.getParameterSpec();
+            }
+        } else {
+            throw new InvalidKeyException(
+                    "Cannot use a " + algorithm + " service with a key that " +
+                    "does not implement javax.crypto.interfaces.PBEKey");
+        }
+        return params;
+    }
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -519,8 +519,9 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static class P11PBEKey extends P11SecretKey implements PBEKey {
-        private static final long serialVersionUID = -7828241727014329084L;
+    private static final class P11PBEKey extends P11SecretKey
+            implements PBEKey {
+        private static final long serialVersionUID = 6847576994253634876L;
         private final char[] password;
         private final byte[] salt;
         private final int iterationCount;
@@ -535,12 +536,12 @@ abstract class P11Key implements Key, Length {
 
         @Override
         public char[] getPassword() {
-            return password;
+            return password.clone();
         }
 
         @Override
         public byte[] getSalt() {
-            return salt;
+            return salt.clone();
         }
 
         @Override

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -341,6 +341,18 @@ abstract class P11Key implements Key, Length {
                 attributes);
     }
 
+    static SecretKey pbeKey(Session session, long keyID, String algorithm,
+            int keyLength, CK_ATTRIBUTE[] attributes,
+            char[] password, byte[] salt, int iterationCount) {
+        attributes = getAttributes(session, keyID, attributes, new CK_ATTRIBUTE[] {
+            new CK_ATTRIBUTE(CKA_TOKEN),
+            new CK_ATTRIBUTE(CKA_SENSITIVE),
+            new CK_ATTRIBUTE(CKA_EXTRACTABLE),
+        });
+        return new P11PBEKey(session, keyID, algorithm, keyLength,
+                attributes, password, salt, iterationCount);
+    }
+
     static SecretKey masterSecretKey(Session session, long keyID, String algorithm,
             int keyLength, CK_ATTRIBUTE[] attributes, int major, int minor) {
         attributes = getAttributes(session, keyID, attributes, new CK_ATTRIBUTE[] {
@@ -504,6 +516,36 @@ abstract class P11Key implements Key, Length {
                 }
             }
             return b;
+        }
+    }
+
+    private static class P11PBEKey extends P11SecretKey implements PBEKey {
+        private static final long serialVersionUID = -7828241727014329084L;
+        private final char[] password;
+        private final byte[] salt;
+        private final int iterationCount;
+        P11PBEKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attributes,
+                char[] password, byte[] salt, int iterationCount) {
+            super(session, keyID, algorithm, keyLength, attributes);
+            this.password = password;
+            this.salt = salt;
+            this.iterationCount = iterationCount;
+        }
+
+        @Override
+        public char[] getPassword() {
+            return password;
+        }
+
+        @Override
+        public byte[] getSalt() {
+            return salt;
+        }
+
+        @Override
+        public int getIterationCount() {
+            return iterationCount;
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -205,7 +205,9 @@ final class P11Mac extends MacSpi {
     // see JCE spec
     protected void engineInit(Key key, AlgorithmParameterSpec params)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
-        if (algorithm.startsWith("HmacPBE")) {
+        if (algorithm.startsWith("HmacPBE") && !(key instanceof P11Key)) {
+            // Derive for compatibility with SunJCE's
+            // password-only com.sun.crypto.provider.PBEKey
             PBEKeySpec pbeSpec = PBEUtil.getPBAKeySpec(key, params);
             reset(true);
             try {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -64,6 +64,9 @@ final class P11Mac extends MacSpi {
     // algorithm name
     private final String algorithm;
 
+    // PBEKeyInfo if algorithm is PBE
+    private final P11SecretKeyFactory.PBEKeyInfo svcPbeKi;
+
     // whether the algorithm is a PBE one
     private final boolean isPbeAlg;
 
@@ -90,7 +93,8 @@ final class P11Mac extends MacSpi {
         super();
         this.token = token;
         this.algorithm = algorithm;
-        this.isPbeAlg = algorithm.startsWith("HmacPBE");
+        this.svcPbeKi = P11SecretKeyFactory.getPBEKeyInfo(algorithm);
+        this.isPbeAlg = this.svcPbeKi != null;
         Long params = null;
         switch ((int)mechanism) {
         case (int)CKM_MD5_HMAC:
@@ -219,7 +223,7 @@ final class P11Mac extends MacSpi {
                 PBEKeySpec pbeSpec = PBEUtil.getPBAKeySpec(key, params);
                 try {
                     p11Key = P11SecretKeyFactory.derivePBEKey(
-                            token, pbeSpec, algorithm);
+                            token, pbeSpec, svcPbeKi);
                 } catch (InvalidKeySpecException e) {
                     throw new InvalidKeyException(e);
                 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Mac.java
@@ -205,11 +205,11 @@ final class P11Mac extends MacSpi {
     // see JCE spec
     protected void engineInit(Key key, AlgorithmParameterSpec params)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
+        reset(true);
         if (algorithm.startsWith("HmacPBE") && !(key instanceof P11Key)) {
             // Derive for compatibility with SunJCE's
             // password-only com.sun.crypto.provider.PBEKey
             PBEKeySpec pbeSpec = PBEUtil.getPBAKeySpec(key, params);
-            reset(true);
             try {
                 p11Key = P11SecretKeyFactory.derivePBEKey(
                         token, pbeSpec, algorithm);
@@ -221,7 +221,6 @@ final class P11Mac extends MacSpi {
                 throw new InvalidAlgorithmParameterException
                     ("Parameters not supported");
             }
-            reset(true);
             p11Key = P11SecretKeyFactory.convertKey(token, key, algorithm);
         }
         try {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PBECipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PBECipher.java
@@ -133,17 +133,15 @@ final class P11PBECipher extends CipherSpi {
                     throws InvalidKeyException,
                     InvalidAlgorithmParameterException {
 
-        PBEKeySpec pbeSpec = pbes2Helper.getPBEKeySpec(blkSize, keyLen,
-                opmode, key, params, random);
-
-        Key derivedKey;
+        PBEKeySpec pbeSpec = pbes2Helper.getPBEKeySpec(
+                blkSize, keyLen, opmode, key, params, random);
         try {
-            derivedKey = P11SecretKeyFactory.derivePBEKey(
-                    token, pbeSpec, pbeAlg);
+            key = P11SecretKeyFactory.derivePBEKey(token, pbeSpec, pbeAlg);
         } catch (InvalidKeySpecException e) {
             throw new InvalidKeyException(e);
         }
-        cipher.engineInit(opmode, derivedKey, pbes2Helper.getIvSpec(), random);
+        params = pbes2Helper.getIvSpec();
+        cipher.engineInit(opmode, key, params, random);
     }
 
     // see JCE spec

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -140,13 +140,15 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         if (key instanceof SecretKey == false) {
             throw new InvalidKeyException("Key must be a SecretKey");
         }
+
+        final String keyAlgo = key.getAlgorithm();
         long algoType;
         if (algo == null) {
-            algo = key.getAlgorithm();
+            algo = keyAlgo;
             algoType = getKeyType(algo);
         } else {
             algoType = getKeyType(algo);
-            long keyAlgorithmType = getKeyType(key.getAlgorithm());
+            long keyAlgorithmType = getKeyType(keyAlgo);
             if (algoType != keyAlgorithmType) {
                 if ((algoType == PCKK_HMAC) || (algoType == PCKK_SSLMAC)) {
                     // ignore key algorithm for MACs

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -287,10 +287,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
                     new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY),
                     new CK_ATTRIBUTE(CKA_VALUE_LEN, keySize >> 3),
                     new CK_ATTRIBUTE(CKA_KEY_TYPE, keyType),
-                    switch (kdfData.op) {
-                        case ENCRYPTION -> CK_ATTRIBUTE.ENCRYPT_TRUE;
-                        case AUTHENTICATION -> CK_ATTRIBUTE.SIGN_TRUE;
-                    },
+                    kdfData.encrypt_or_sign_true,
             };
             CK_ATTRIBUTE[] attr = token.getAttributes(
                     O_GENERATE, CKO_SECRET_KEY, keyType, attrs);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -53,76 +53,206 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
     // algorithm name
     private final String algorithm;
 
+    // PBEKeyInfo if algorithm is PBE
+    private final PBEKeyInfo svcPbeKi;
+
     P11SecretKeyFactory(Token token, String algorithm) {
         super();
         this.token = token;
         this.algorithm = algorithm;
+        this.svcPbeKi = getPBEKeyInfo(algorithm);
     }
 
-    private static final Map<String,Long> keyTypes;
+    private static final Map<String, KeyInfo> keyInfo = new HashMap<>();
+    private static final KeyInfo HMAC = new KeyInfo("HMAC", PCKK_HMAC);
+    private static final KeyInfo SSLMAC = new KeyInfo("SSLMAC", PCKK_SSLMAC);
+
+    static KeyInfo getKeyInfo(String algo) {
+        KeyInfo ki = keyInfo.get(algo);
+        if (ki == null) {
+            String algoUpper = algo.toUpperCase(Locale.ENGLISH);
+            ki = keyInfo.get(algoUpper);
+            if (ki == null) {
+                if (algoUpper.startsWith("HMAC")) {
+                    return HMAC;
+                } else if (algoUpper.startsWith("SSLMAC")) {
+                    return SSLMAC;
+                }
+            }
+        }
+        return ki;
+    }
+
+    static PBEKeyInfo getPBEKeyInfo(String algo) {
+        if (getKeyInfo(algo) instanceof PBEKeyInfo pbeKi) {
+            return pbeKi;
+        }
+        return null;
+    }
+
+    private static void putKeyInfo(KeyInfo ki) {
+        keyInfo.put(ki.algo, ki);
+        keyInfo.put(ki.algo.toUpperCase(Locale.ENGLISH), ki);
+    }
+
+    static sealed class KeyInfo permits PBEKeyInfo {
+        public final String algo;
+        public final long keyType;
+
+        KeyInfo(String algo, long keyType) {
+            this.algo = algo;
+            this.keyType = keyType;
+        }
+
+        static boolean checkUse(KeyInfo ki, KeyInfo si) {
+            if (si instanceof PBEKeyInfo && !si.algo.equals(ki.algo)) {
+                // PBE services require a PBE key of the same algorithm.
+                return false;
+            }
+            if (ki instanceof PBKDF2KeyInfo) {
+                // We cannot tell what the PBE key was derived for,
+                // so any service is allowed in principle.
+                return true;
+            }
+            return ki.keyType == si.keyType;
+        }
+    }
+
+    static abstract sealed class PBEKeyInfo extends KeyInfo
+            permits AESPBEKeyInfo, PBKDF2KeyInfo, P12MacPBEKeyInfo {
+        public static final long INVALID_PRF = -1;
+        public final long kdfMech;
+        public final long prfMech;
+        public final int keyLen;
+        public final CK_ATTRIBUTE[] extraAttrs;
+
+        protected PBEKeyInfo(String algo, long kdfMech, long prfMech,
+                long keyType, int keyLen, CK_ATTRIBUTE[] extraAttrs) {
+            super(algo, keyType);
+            this.kdfMech = kdfMech;
+            this.prfMech = prfMech;
+            this.keyLen = keyLen;
+            this.extraAttrs = extraAttrs;
+        }
+    }
+
+    static final class AESPBEKeyInfo extends PBEKeyInfo {
+        private static final CK_ATTRIBUTE[] attr = new CK_ATTRIBUTE[] {
+                CK_ATTRIBUTE.ENCRYPT_TRUE};
+
+        AESPBEKeyInfo(String algo, long prfMech, int keyLen) {
+            super(algo, CKM_PKCS5_PBKD2, prfMech, CKK_AES, keyLen, attr);
+        }
+    }
+
+    static final class PBKDF2KeyInfo extends PBEKeyInfo {
+        private static final CK_ATTRIBUTE[] attr = new CK_ATTRIBUTE[] {
+                CK_ATTRIBUTE.ENCRYPT_TRUE, CK_ATTRIBUTE.SIGN_TRUE};
+
+        PBKDF2KeyInfo(String algo, long prfMech) {
+            super(algo, CKM_PKCS5_PBKD2, prfMech, CKK_GENERIC_SECRET, -1, attr);
+        }
+    }
+
+    static final class P12MacPBEKeyInfo extends PBEKeyInfo {
+        private static final CK_ATTRIBUTE[] attr = new CK_ATTRIBUTE[] {
+                CK_ATTRIBUTE.SIGN_TRUE};
+
+        P12MacPBEKeyInfo(String algo, long kdfMech, int keyLen) {
+            super(algo, kdfMech, PBEKeyInfo.INVALID_PRF,
+                    CKK_GENERIC_SECRET, keyLen, attr);
+        }
+    }
 
     static {
-        keyTypes = new HashMap<String,Long>();
-        addKeyType("RC4",      CKK_RC4);
-        addKeyType("ARCFOUR",  CKK_RC4);
-        addKeyType("DES",      CKK_DES);
-        addKeyType("DESede",   CKK_DES3);
-        addKeyType("AES",      CKK_AES);
-        addKeyType("Blowfish", CKK_BLOWFISH);
-        addKeyType("ChaCha20", CKK_CHACHA20);
-        addKeyType("ChaCha20-Poly1305", CKK_CHACHA20);
+        putKeyInfo(new KeyInfo("RC4", CKK_RC4));
+        putKeyInfo(new KeyInfo("ARCFOUR", CKK_RC4));
+        putKeyInfo(new KeyInfo("DES", CKK_DES));
+        putKeyInfo(new KeyInfo("DESede", CKK_DES3));
+        putKeyInfo(new KeyInfo("AES", CKK_AES));
+        putKeyInfo(new KeyInfo("Blowfish", CKK_BLOWFISH));
+        putKeyInfo(new KeyInfo("ChaCha20", CKK_CHACHA20));
+        putKeyInfo(new KeyInfo("ChaCha20-Poly1305", CKK_CHACHA20));
 
         // we don't implement RC2 or IDEA, but we want to be able to generate
         // keys for those SSL/TLS ciphersuites.
-        addKeyType("RC2",      CKK_RC2);
-        addKeyType("IDEA",     CKK_IDEA);
+        putKeyInfo(new KeyInfo("RC2", CKK_RC2));
+        putKeyInfo(new KeyInfo("IDEA", CKK_IDEA));
 
-        addKeyType("TlsPremasterSecret",    PCKK_TLSPREMASTER);
-        addKeyType("TlsRsaPremasterSecret", PCKK_TLSRSAPREMASTER);
-        addKeyType("TlsMasterSecret",       PCKK_TLSMASTER);
-        addKeyType("Generic",               CKK_GENERIC_SECRET);
+        putKeyInfo(new KeyInfo("TlsPremasterSecret", PCKK_TLSPREMASTER));
+        putKeyInfo(new KeyInfo("TlsRsaPremasterSecret", PCKK_TLSRSAPREMASTER));
+        putKeyInfo(new KeyInfo("TlsMasterSecret", PCKK_TLSMASTER));
+        putKeyInfo(new KeyInfo("Generic", CKK_GENERIC_SECRET));
+
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA1AndAES_128",
+                CKP_PKCS5_PBKD2_HMAC_SHA1, 128));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA224AndAES_128",
+                CKP_PKCS5_PBKD2_HMAC_SHA224, 128));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA256AndAES_128",
+                CKP_PKCS5_PBKD2_HMAC_SHA256, 128));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA384AndAES_128",
+                CKP_PKCS5_PBKD2_HMAC_SHA384, 128));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA512AndAES_128",
+                CKP_PKCS5_PBKD2_HMAC_SHA512, 128));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA1AndAES_256",
+                CKP_PKCS5_PBKD2_HMAC_SHA1, 256));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA224AndAES_256",
+                CKP_PKCS5_PBKD2_HMAC_SHA224, 256));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA256AndAES_256",
+                CKP_PKCS5_PBKD2_HMAC_SHA256, 256));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA384AndAES_256",
+                CKP_PKCS5_PBKD2_HMAC_SHA384, 256));
+        putKeyInfo(new AESPBEKeyInfo("PBEWithHmacSHA512AndAES_256",
+                CKP_PKCS5_PBKD2_HMAC_SHA512, 256));
+
+        putKeyInfo(new PBKDF2KeyInfo("PBKDF2WithHmacSHA1",
+                CKP_PKCS5_PBKD2_HMAC_SHA1));
+        putKeyInfo(new PBKDF2KeyInfo("PBKDF2WithHmacSHA224",
+                CKP_PKCS5_PBKD2_HMAC_SHA224));
+        putKeyInfo(new PBKDF2KeyInfo("PBKDF2WithHmacSHA256",
+                CKP_PKCS5_PBKD2_HMAC_SHA256));
+        putKeyInfo(new PBKDF2KeyInfo("PBKDF2WithHmacSHA384",
+                CKP_PKCS5_PBKD2_HMAC_SHA384));
+        putKeyInfo(new PBKDF2KeyInfo("PBKDF2WithHmacSHA512",
+                CKP_PKCS5_PBKD2_HMAC_SHA512));
+
+        putKeyInfo(new P12MacPBEKeyInfo("HmacPBESHA1",
+                CKM_PBA_SHA1_WITH_SHA1_HMAC, 160));
+        putKeyInfo(new P12MacPBEKeyInfo("HmacPBESHA224",
+                CKM_NSS_PKCS12_PBE_SHA224_HMAC_KEY_GEN, 224));
+        putKeyInfo(new P12MacPBEKeyInfo("HmacPBESHA256",
+                CKM_NSS_PKCS12_PBE_SHA256_HMAC_KEY_GEN, 256));
+        putKeyInfo(new P12MacPBEKeyInfo("HmacPBESHA384",
+                CKM_NSS_PKCS12_PBE_SHA384_HMAC_KEY_GEN, 384));
+        putKeyInfo(new P12MacPBEKeyInfo("HmacPBESHA512",
+                CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512));
+        putKeyInfo(new P12MacPBEKeyInfo("HmacPBESHA512/224",
+                CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512));
+        putKeyInfo(new P12MacPBEKeyInfo("HmacPBESHA512/256",
+                CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512));
     }
 
-    private static void addKeyType(String name, long id) {
-        Long l = Long.valueOf(id);
-        keyTypes.put(name, l);
-        keyTypes.put(name.toUpperCase(Locale.ENGLISH), l);
-    }
-
-    // returns the PKCS11 key type of the specified algorithm
-    // no pseudo KeyTypes
     static long getPKCS11KeyType(String algorithm) {
         long kt = getKeyType(algorithm);
         if (kt == -1 || kt > PCKK_ANY) {
+            // Replace pseudo key type.
             kt = CKK_GENERIC_SECRET;
         }
         return kt;
     }
 
-    // returns direct lookup result of keyTypes using algorithm
     static long getKeyType(String algorithm) {
-        Long l = keyTypes.get(algorithm);
-        if (l == null) {
-            algorithm = algorithm.toUpperCase(Locale.ENGLISH);
-            l = keyTypes.get(algorithm);
-            if (l == null) {
-                if (algorithm.startsWith("HMAC")) {
-                    return PCKK_HMAC;
-                } else if (algorithm.startsWith("SSLMAC")) {
-                    return PCKK_SSLMAC;
-                }
-            }
-        }
-        return (l != null) ? l.longValue() : -1;
+        KeyInfo ki = getKeyInfo(algorithm);
+        return ki == null ? -1 : ki.keyType;
     }
 
     /**
      * Convert an arbitrary key of algorithm into a P11Key of provider.
      * Used in engineTranslateKey(), P11Cipher.init(), and P11Mac.init().
      */
-    static P11Key convertKey(Token token, Key key, String algo)
+    static P11Key convertKey(Token token, Key key, String svcAlgo)
             throws InvalidKeyException {
-        return convertKey(token, key, algo, null);
+        return convertKey(token, key, svcAlgo, null);
     }
 
     /**
@@ -130,42 +260,33 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
      * P11Key of provider.
      * Used in P11KeyStore.storeSkey.
      */
-    static P11Key convertKey(Token token, Key key, String algo,
+    static P11Key convertKey(Token token, Key key, String svcAlgo,
             CK_ATTRIBUTE[] extraAttrs)
             throws InvalidKeyException {
         token.ensureValid();
-        if (key == null) {
-            throw new InvalidKeyException("Key must not be null");
-        }
-        if (key instanceof SecretKey == false) {
+        if (!(key instanceof SecretKey)) {
             throw new InvalidKeyException("Key must be a SecretKey");
         }
-
         final String keyAlgo = key.getAlgorithm();
-        if (key instanceof PBEKey && keyAlgo != null && algo != null) {
-            P11Util.KDFData kdfData = P11Util.kdfDataMap.get(keyAlgo);
-            if (kdfData != null && (keyAlgo.equals(algo) ||
-                    kdfData.keyAlgo.equals(algo))) {
-                return key instanceof P11Key ?
-                        (P11Key) key : // already derived
-                        derivePBEKey(token, (PBEKey) key, algo);
-            }
+        if (keyAlgo == null) {
+            throw new InvalidKeyException("Key must specify its algorithm");
         }
-
-        long algoType;
-        if (algo == null) {
-            algo = keyAlgo;
-            algoType = getKeyType(algo);
-        } else {
-            algoType = getKeyType(algo);
-            long keyAlgorithmType = getKeyType(keyAlgo);
-            if (algoType != keyAlgorithmType) {
-                if ((algoType == PCKK_HMAC) || (algoType == PCKK_SSLMAC)) {
-                    // ignore key algorithm for MACs
-                } else {
-                    throw new InvalidKeyException
-                            ("Key algorithm must be " + algo);
-                }
+        if (svcAlgo == null) {
+            svcAlgo = keyAlgo;
+        }
+        KeyInfo ki = null;
+        KeyInfo si = getKeyInfo(svcAlgo);
+        if (si == null) {
+            throw new InvalidKeyException("Unknown algorithm " + svcAlgo);
+        }
+        // Check if the key can be used for the service.
+        // Any key can be used for a MAC service.
+        if (svcAlgo != keyAlgo &&
+                si.keyType != PCKK_HMAC && si.keyType != PCKK_SSLMAC) {
+            ki = getKeyInfo(keyAlgo);
+            if (ki == null || !KeyInfo.checkUse(ki, si)) {
+                throw new InvalidKeyException("Cannot use a " + keyAlgo +
+                        " key for a " + svcAlgo + " service");
             }
         }
         if (key instanceof P11Key) {
@@ -198,17 +319,34 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         if (p11Key != null) {
             return p11Key;
         }
-        if ("RAW".equalsIgnoreCase(key.getFormat()) == false) {
-            throw new InvalidKeyException("Encoded format must be RAW");
+        if (key instanceof PBEKey pbeKey) {
+            ki = ki == null ? getKeyInfo(keyAlgo) : ki;
+            if (ki instanceof PBEKeyInfo pbeKi) {
+                try {
+                    p11Key = derivePBEKey(token, getPbeKeySpec(pbeKey), pbeKi);
+                } catch (InvalidKeySpecException e) {
+                    throw new InvalidKeyException(e);
+                }
+            } else {
+                throw new InvalidKeyException("Cannot derive unknown " +
+                        keyAlgo + " algorithm");
+            }
+        } else {
+            if (si instanceof PBEKeyInfo) {
+                throw new InvalidKeyException("PBE service requires a PBE key");
+            }
+            if (!"RAW".equalsIgnoreCase(key.getFormat())) {
+                throw new InvalidKeyException("Encoded format must be RAW");
+            }
+            byte[] encoded = key.getEncoded();
+            p11Key = createKey(token, encoded, svcAlgo, si.keyType, extraAttrs);
         }
-        byte[] encoded = key.getEncoded();
-        p11Key = createKey(token, encoded, algo, algoType, extraAttrs);
         token.secretCache.put(key, p11Key);
         return p11Key;
     }
 
-    static P11Key derivePBEKey(Token token, PBEKeySpec keySpec, String algo)
-            throws InvalidKeySpecException {
+    static P11Key derivePBEKey(Token token, PBEKeySpec keySpec,
+            PBEKeyInfo pbeKi) throws InvalidKeySpecException {
         token.ensureValid();
         if (keySpec == null) {
             throw new InvalidKeySpecException("PBEKeySpec must not be null");
@@ -216,95 +354,97 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         Session session = null;
         try {
             session = token.getObjSession();
-            P11Util.KDFData kdfData = P11Util.kdfDataMap.get(algo);
             CK_MECHANISM ckMech;
             char[] password = keySpec.getPassword();
             byte[] salt = keySpec.getSalt();
             int itCount = keySpec.getIterationCount();
             int keySize = keySpec.getKeyLength();
-            if (kdfData.keyLen != -1) {
+            assert password != null :
+                    "PBEKeySpec does not allow a null password";
+            if (salt == null) {
+                throw new InvalidKeySpecException("Salt not found");
+            }
+            assert salt.length > 0 : "PBEKeySpec does not allow an empty salt";
+            if (itCount < 1) {
+                throw new InvalidKeySpecException("Iteration count must be " +
+                        "a non-zero positive integer");
+            }
+            if (pbeKi.keyLen > 0) {
                 if (keySize == 0) {
-                    keySize = kdfData.keyLen;
-                } else if (keySize != kdfData.keyLen) {
+                    keySize = pbeKi.keyLen;
+                } else if (keySize != pbeKi.keyLen) {
                     throw new InvalidKeySpecException(
-                            "Key length is invalid for " + algo);
+                            "Key length is invalid for " + pbeKi.algo + " (" +
+                            "expecting " + pbeKi.keyLen + " but was " +
+                            keySize + ")");
                 }
             }
-            if (itCount < 1) {
-                throw new InvalidKeySpecException(
-                        "Iteration count must be a non-zero positive integer");
-            }
-            if (keySize < 1) {
-                throw new InvalidKeySpecException(
-                        "Key length must be a non-zero positive integer");
-            }
-            if (keySize % 8 != 0) {
-                throw new InvalidKeySpecException(
-                        "Key length (in bits) must be a multiple of 8");
+            if (keySize < 1 || keySize % 8 != 0) {
+                throw new InvalidKeySpecException("Key length must be " +
+                        "multiple of 8 and greater than zero");
             }
 
-            if (kdfData.kdfMech == CKM_PKCS5_PBKD2) {
+            if (pbeKi.kdfMech == CKM_PKCS5_PBKD2) {
                 CK_INFO p11Info = token.p11.getInfo();
                 CK_VERSION p11Ver = (p11Info != null ? p11Info.cryptokiVersion
                         : null);
                 if (P11Util.isNSS(token) || p11Ver != null && (p11Ver.major <
                         2 || p11Ver.major == 2 && p11Ver.minor < 40)) {
-                    // NSS keeps using the old structure beyond PKCS #11 v2.40
-                    ckMech = new CK_MECHANISM(kdfData.kdfMech,
+                    // NSS keeps using the old structure beyond PKCS #11 v2.40.
+                    ckMech = new CK_MECHANISM(pbeKi.kdfMech,
                             new CK_PKCS5_PBKD2_PARAMS(password, salt,
-                                    itCount, kdfData.prfMech));
+                                    itCount, pbeKi.prfMech));
                 } else {
-                    ckMech = new CK_MECHANISM(kdfData.kdfMech,
+                    ckMech = new CK_MECHANISM(pbeKi.kdfMech,
                             new CK_PKCS5_PBKD2_PARAMS2(password, salt,
-                                    itCount, kdfData.prfMech));
+                                    itCount, pbeKi.prfMech));
                 }
             } else {
-                // PKCS #12 "General Method" PBKD (RFC 7292, Appendix B.2)
+                // PKCS #12 "General Method" PBKD (RFC 7292, Appendix B.2).
                 char[] expPassword = password;
                 if (P11Util.isNSS(token)) {
-                    // According to PKCS #11, "password" in CK_PBE_PARAMS has
-                    // a CK_UTF8CHAR_PTR type. This suggests that it is encoded
-                    // in UTF-8. However, NSS expects the password to be encoded
-                    // as BMPString with a NULL terminator when C_GenerateKey
-                    // is called for a PKCS #12 "General Method" derivation
-                    // (see RFC 7292, Appendix B.1).
-                    //
-                    // The char size in Java is 2 bytes. When a char is
-                    // converted to a CK_UTF8CHAR, the high-order byte is
-                    // discarded (see jCharArrayToCKUTF8CharArray in
-                    // p11_util.c). In order to have a BMPString passed to
-                    // C_GenerateKey, we need to account for that and expand:
-                    // the high and low parts of each char are split into 2
-                    // chars. As an example, this is the transformation for
-                    // a NULL terminated password "a":
-                    //   char[] password    =>  [    0x0061,         0x0000    ]
-                    //                               /    \          /    \
-                    //   char[] expPassword =>  [0x0000, 0x0061, 0x0000, 0x0000]
-                    //                               |       |       |       |
-                    //   byte[] BMPString   =>  [  0x00,   0x61,   0x00,   0x00]
-                    //
-                    int inputLength = (password == null) ? 0 : password.length;
-                    expPassword = new char[inputLength * 2 + 2];
-                    for (int i = 0, j = 0; i < inputLength; i++, j += 2) {
+                    /* According to PKCS #11, "password" in CK_PBE_PARAMS has
+                     * a CK_UTF8CHAR_PTR type. This suggests that it is encoded
+                     * in UTF-8. However, NSS expects the password to be encoded
+                     * as BMPString with a NULL terminator when C_GenerateKey
+                     * is called for a PKCS #12 "General Method" derivation
+                     * (see RFC 7292, Appendix B.1).
+                     *
+                     * The char size in Java is 2 bytes. When a char is
+                     * converted to a CK_UTF8CHAR, the high-order byte is
+                     * discarded (see jCharArrayToCKUTF8CharArray in
+                     * p11_util.c). In order to have a BMPString passed to
+                     * C_GenerateKey, we need to account for that and expand:
+                     * the high and low parts of each char are split into 2
+                     * chars. As an example, this is the transformation for
+                     * a NULL terminated password "a":
+                     *   char[] password    =>  [    0x0061,         0x0000    ]
+                     *                               /    \          /    \
+                     *   char[] expPassword =>  [0x0000, 0x0061, 0x0000, 0x0000]
+                     *                               |       |       |       |
+                     *   byte[] BMPString   =>  [  0x00,   0x61,   0x00,   0x00]
+                     */
+                    expPassword = new char[password.length * 2 + 2];
+                    for (int i = 0, j = 0; i < password.length; i++, j += 2) {
                         expPassword[j] = (char) ((password[i] >>> 8) & 0xFF);
                         expPassword[j + 1] = (char) (password[i] & 0xFF);
                     }
                 }
-                ckMech = new CK_MECHANISM(kdfData.kdfMech,
+                ckMech = new CK_MECHANISM(pbeKi.kdfMech,
                         new CK_PBE_PARAMS(expPassword, salt, itCount));
             }
 
-            CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[] {
-                    new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY),
-                    new CK_ATTRIBUTE(CKA_VALUE_LEN, keySize >> 3),
-                    new CK_ATTRIBUTE(CKA_KEY_TYPE,
-                            getPKCS11KeyType(kdfData.keyAlgo)),
-                    kdfData.encrypt_or_sign_true,
-            };
-            CK_ATTRIBUTE[] attr = token.getAttributes(O_GENERATE,
-                    CKO_SECRET_KEY, getKeyType(kdfData.keyAlgo), attrs);
+            CK_ATTRIBUTE[] attrs =
+                    new CK_ATTRIBUTE[3 + pbeKi.extraAttrs.length];
+            attrs[0] = new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY);
+            attrs[1] = new CK_ATTRIBUTE(CKA_VALUE_LEN, keySize >> 3);
+            attrs[2] = new CK_ATTRIBUTE(CKA_KEY_TYPE, pbeKi.keyType);
+            System.arraycopy(pbeKi.extraAttrs, 0, attrs, 3,
+                    pbeKi.extraAttrs.length);
+            CK_ATTRIBUTE[] attr = token.getAttributes(
+                    O_GENERATE, CKO_SECRET_KEY, pbeKi.keyType, attrs);
             long keyID = token.p11.C_GenerateKey(session.id(), ckMech, attr);
-            return (P11Key) P11Key.pbeKey(session, keyID, algo,
+            return (P11Key) P11Key.pbeKey(session, keyID, pbeKi.algo,
                     keySize, attr, password, salt, itCount);
         } catch (PKCS11Exception e) {
             throw new InvalidKeySpecException("Could not create key", e);
@@ -315,7 +455,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
 
     private static PBEKeySpec getPbeKeySpec(PBEKey pbeKey) {
         int keyLength = 0;
-        if ("RAW".equals(pbeKey.getFormat())) {
+        if ("RAW".equalsIgnoreCase(pbeKey.getFormat())) {
             byte[] encoded = pbeKey.getEncoded();
             if (encoded != null) {
                 keyLength = encoded.length << 3;
@@ -327,25 +467,6 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         return keyLength == 0 ?
                 new PBEKeySpec(pwd, salt, ic) :
                 new PBEKeySpec(pwd, salt, ic, keyLength);
-    }
-
-    static P11Key derivePBEKey(Token token, PBEKey key, String algo)
-            throws InvalidKeyException {
-        token.ensureValid();
-        if (key == null) {
-            throw new InvalidKeyException("PBEKey must not be null");
-        }
-        P11Key p11Key = token.secretCache.get(key);
-        if (p11Key != null) {
-            return p11Key;
-        }
-        try {
-            p11Key = derivePBEKey(token, getPbeKeySpec(key), algo);
-        } catch (InvalidKeySpecException e) {
-            throw new InvalidKeyException(e);
-        }
-        token.secretCache.put(key, p11Key);
-        return p11Key;
     }
 
     static void fixDESParity(byte[] key, int offset) {
@@ -455,28 +576,28 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         if (keySpec == null) {
             throw new InvalidKeySpecException("KeySpec must not be null");
         }
-        if (keySpec instanceof SecretKeySpec) {
+        if (keySpec instanceof SecretKeySpec secretKeySpec) {
             try {
-                Key key = convertKey(token, (SecretKey)keySpec, algorithm);
+                Key key = convertKey(token, secretKeySpec, algorithm);
                 return (SecretKey)key;
             } catch (InvalidKeyException e) {
                 throw new InvalidKeySpecException(e);
             }
+        } else if (keySpec instanceof PBEKeySpec pbeKeySpec &&
+                svcPbeKi != null) {
+            return (SecretKey) derivePBEKey(token, pbeKeySpec, svcPbeKi);
         } else if (algorithm.equalsIgnoreCase("DES")) {
-            if (keySpec instanceof DESKeySpec) {
-                byte[] keyBytes = ((DESKeySpec)keySpec).getKey();
+            if (keySpec instanceof DESKeySpec desKeySpec) {
+                byte[] keyBytes = desKeySpec.getKey();
                 keySpec = new SecretKeySpec(keyBytes, "DES");
                 return engineGenerateSecret(keySpec);
             }
         } else if (algorithm.equalsIgnoreCase("DESede")) {
-            if (keySpec instanceof DESedeKeySpec) {
-                byte[] keyBytes = ((DESedeKeySpec)keySpec).getKey();
+            if (keySpec instanceof DESedeKeySpec desEdeKeySpec) {
+                byte[] keyBytes = desEdeKeySpec.getKey();
                 keySpec = new SecretKeySpec(keyBytes, "DESede");
                 return engineGenerateSecret(keySpec);
             }
-        } else if (keySpec instanceof PBEKeySpec) {
-            return (SecretKey)derivePBEKey(token,
-                    (PBEKeySpec)keySpec, algorithm);
         }
         throw new InvalidKeySpecException
                 ("Unsupported spec: " + keySpec.getClass().getName());
@@ -485,9 +606,8 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
     private byte[] getKeyBytes(SecretKey key) throws InvalidKeySpecException {
         try {
             key = engineTranslateKey(key);
-            if ("RAW".equalsIgnoreCase(key.getFormat()) == false) {
-                throw new InvalidKeySpecException
-                    ("Could not obtain key bytes");
+            if (!"RAW".equalsIgnoreCase(key.getFormat())) {
+                throw new InvalidKeySpecException("Could not obtain key bytes");
             }
             byte[] k = key.getEncoded();
             return k;
@@ -506,6 +626,9 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         }
         if (keySpec.isAssignableFrom(SecretKeySpec.class)) {
             return new SecretKeySpec(getKeyBytes(key), algorithm);
+        } else if (keySpec.isAssignableFrom(PBEKeySpec.class) &&
+                key instanceof PBEKey pbeKey && svcPbeKi != null) {
+            return getPbeKeySpec(pbeKey);
         } else if (algorithm.equalsIgnoreCase("DES")) {
             try {
                 if (keySpec.isAssignableFrom(DESKeySpec.class)) {
@@ -522,9 +645,6 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             } catch (InvalidKeyException e) {
                 throw new InvalidKeySpecException(e);
             }
-        } else if (keySpec.isAssignableFrom(PBEKeySpec.class) &&
-                key instanceof PBEKey pbeKey) {
-            return getPbeKeySpec(pbeKey);
         }
         throw new InvalidKeySpecException
                 ("Unsupported spec: " + keySpec.getName());

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -218,6 +218,18 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
                             "Key length is invalid for " + algo);
                 }
             }
+            if (itCount < 1) {
+                throw new InvalidKeySpecException(
+                        "Iteration count must be a non-zero positive integer");
+            }
+            if (keySize < 1) {
+                throw new InvalidKeySpecException(
+                        "Key length must be a non-zero positive integer");
+            }
+            if (keySize % 8 != 0) {
+                throw new InvalidKeySpecException(
+                        "Key length (in bits) must be a multiple of 8");
+            }
 
             if (kdfData.kdfMech == CKM_PKCS5_PBKD2) {
                 CK_INFO p11Info = token.p11.getInfo();

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -284,17 +284,17 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
                         new CK_PBE_PARAMS(expPassword, salt, itCount));
             }
 
-            long keyType = getKeyType(kdfData.keyAlgo);
             CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[] {
                     new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY),
                     new CK_ATTRIBUTE(CKA_VALUE_LEN, keySize >> 3),
-                    new CK_ATTRIBUTE(CKA_KEY_TYPE, keyType),
+                    new CK_ATTRIBUTE(CKA_KEY_TYPE,
+                            getPKCS11KeyType(kdfData.keyAlgo)),
                     kdfData.encrypt_or_sign_true,
             };
-            CK_ATTRIBUTE[] attr = token.getAttributes(
-                    O_GENERATE, CKO_SECRET_KEY, keyType, attrs);
+            CK_ATTRIBUTE[] attr = token.getAttributes(O_GENERATE,
+                    CKO_SECRET_KEY, getKeyType(kdfData.keyAlgo), attrs);
             long keyID = token.p11.C_GenerateKey(session.id(), ckMech, attr);
-            return (P11Key) P11Key.pbeKey(session, keyID, kdfData.keyAlgo,
+            return (P11Key) P11Key.pbeKey(session, keyID, algo,
                     keySize, attr, password, salt, itCount);
         } catch (PKCS11Exception e) {
             throw new InvalidKeySpecException("Could not create key", e);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -283,22 +283,15 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             }
 
             long keyType = getKeyType(kdfData.keyAlgo);
-            CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[
+            CK_ATTRIBUTE[] attrs = new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY),
+                    new CK_ATTRIBUTE(CKA_VALUE_LEN, keySize >> 3),
+                    new CK_ATTRIBUTE(CKA_KEY_TYPE, keyType),
                     switch (kdfData.op) {
-                        case ENCRYPTION, AUTHENTICATION -> 4;
-                        case GENERIC -> 5;
-                    }];
-            attrs[0] = new CK_ATTRIBUTE(CKA_CLASS, CKO_SECRET_KEY);
-            attrs[1] = new CK_ATTRIBUTE(CKA_VALUE_LEN, keySize >> 3);
-            attrs[2] = new CK_ATTRIBUTE(CKA_KEY_TYPE, keyType);
-            switch (kdfData.op) {
-                case ENCRYPTION -> attrs[3] = CK_ATTRIBUTE.ENCRYPT_TRUE;
-                case AUTHENTICATION -> attrs[3] = CK_ATTRIBUTE.SIGN_TRUE;
-                case GENERIC -> {
-                    attrs[3] = CK_ATTRIBUTE.ENCRYPT_TRUE;
-                    attrs[4] = CK_ATTRIBUTE.SIGN_TRUE;
-                }
-            }
+                        case ENCRYPTION -> CK_ATTRIBUTE.ENCRYPT_TRUE;
+                        case AUTHENTICATION -> CK_ATTRIBUTE.SIGN_TRUE;
+                    },
+            };
             CK_ATTRIBUTE[] attr = token.getAttributes(
                     O_GENERATE, CKO_SECRET_KEY, keyType, attrs);
             long keyID = token.p11.C_GenerateKey(session.id(), ckMech, attr);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -29,6 +29,7 @@ import java.math.BigInteger;
 import java.security.*;
 import java.util.HashMap;
 import java.util.Map;
+import sun.security.pkcs11.wrapper.CK_ATTRIBUTE;
 
 import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 
@@ -46,37 +47,36 @@ public final class P11Util {
 
     // Used by PBE
     static final class KDFData {
-        public enum Operation {ENCRYPTION, AUTHENTICATION}
         public long kdfMech;
         public long prfMech;
         public String keyAlgo;
         public int keyLen;
-        public Operation op;
+        public CK_ATTRIBUTE encrypt_or_sign_true;
         KDFData(long kdfMech, long prfMech, String keyAlgo,
-                int keyLen, Operation op) {
+                int keyLen, CK_ATTRIBUTE encrypt_or_sign_true) {
             this.kdfMech = kdfMech;
             this.prfMech = prfMech;
             this.keyAlgo = keyAlgo;
             this.keyLen = keyLen;
-            this.op = op;
+            this.encrypt_or_sign_true = encrypt_or_sign_true;
         }
 
         public static void addPbkdf2Data(String algo, long kdfMech,
                                          long prfMech) {
             kdfDataMap.put(algo, new KDFData(kdfMech, prfMech,
-                    algo, -1, Operation.AUTHENTICATION));
+                    algo, -1, CK_ATTRIBUTE.SIGN_TRUE));
         }
 
         public static void addPbkdf2AesData(String algo, long kdfMech,
                                             long prfMech, int keyLen) {
             kdfDataMap.put(algo, new KDFData(kdfMech, prfMech,
-                    "AES", keyLen, Operation.ENCRYPTION));
+                    "AES", keyLen, CK_ATTRIBUTE.ENCRYPT_TRUE));
         }
 
         public static void addPkcs12KDMacData(String algo, long kdfMech,
                                               int keyLen) {
             kdfDataMap.put(algo, new KDFData(kdfMech, -1,
-                    "Generic", keyLen, Operation.AUTHENTICATION));
+                    "Generic", keyLen, CK_ATTRIBUTE.SIGN_TRUE));
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -47,11 +47,12 @@ public final class P11Util {
 
     // Used by PBE
     static final class KDFData {
-        public long kdfMech;
-        public long prfMech;
-        public String keyAlgo;
-        public int keyLen;
-        public CK_ATTRIBUTE encrypt_or_sign_true;
+        public final long kdfMech;
+        public final long prfMech;
+        public final String keyAlgo;
+        public final int keyLen;
+        public final CK_ATTRIBUTE encrypt_or_sign_true;
+
         KDFData(long kdfMech, long prfMech, String keyAlgo,
                 int keyLen, CK_ATTRIBUTE encrypt_or_sign_true) {
             this.kdfMech = kdfMech;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -64,7 +64,7 @@ public final class P11Util {
         public static void addPbkdf2Data(String algo, long kdfMech,
                                          long prfMech) {
             kdfDataMap.put(algo, new KDFData(kdfMech, prfMech,
-                    "Generic", -1, Operation.GENERIC));
+                    algo, -1, Operation.GENERIC));
         }
 
         public static void addPbkdf2AesData(String algo, long kdfMech,

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -77,7 +77,7 @@ public final class P11Util {
         public static void addPkcs12KDMacData(String algo, long kdfMech,
                                               int keyLen) {
             kdfDataMap.put(algo, new KDFData(kdfMech, -1,
-                    "Generic", keyLen, CK_ATTRIBUTE.SIGN_TRUE));
+                    "HMAC", keyLen, CK_ATTRIBUTE.SIGN_TRUE));
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -73,8 +73,8 @@ public final class P11Util {
                     "AES", keyLen, Operation.ENCRYPTION));
         }
 
-        public static void addPkcs12KDData(String algo, long kdfMech,
-                                         int keyLen) {
+        public static void addPkcs12KDMacData(String algo, long kdfMech,
+                                              int keyLen) {
             kdfDataMap.put(algo, new KDFData(kdfMech, -1,
                     "Generic", keyLen, Operation.AUTHENTICATION));
         }
@@ -115,19 +115,19 @@ public final class P11Util {
         KDFData.addPbkdf2Data("PBKDF2WithHmacSHA512",
                 CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA512);
 
-        KDFData.addPkcs12KDData("HmacPBESHA1",
+        KDFData.addPkcs12KDMacData("HmacPBESHA1",
                 CKM_PBA_SHA1_WITH_SHA1_HMAC, 160);
-        KDFData.addPkcs12KDData("HmacPBESHA224",
+        KDFData.addPkcs12KDMacData("HmacPBESHA224",
                 CKM_NSS_PKCS12_PBE_SHA224_HMAC_KEY_GEN, 224);
-        KDFData.addPkcs12KDData("HmacPBESHA256",
+        KDFData.addPkcs12KDMacData("HmacPBESHA256",
                 CKM_NSS_PKCS12_PBE_SHA256_HMAC_KEY_GEN, 256);
-        KDFData.addPkcs12KDData("HmacPBESHA384",
+        KDFData.addPkcs12KDMacData("HmacPBESHA384",
                 CKM_NSS_PKCS12_PBE_SHA384_HMAC_KEY_GEN, 384);
-        KDFData.addPkcs12KDData("HmacPBESHA512",
+        KDFData.addPkcs12KDMacData("HmacPBESHA512",
                 CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512);
-        KDFData.addPkcs12KDData("HmacPBESHA512/224",
+        KDFData.addPkcs12KDMacData("HmacPBESHA512/224",
                 CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512);
-        KDFData.addPkcs12KDData("HmacPBESHA512/256",
+        KDFData.addPkcs12KDMacData("HmacPBESHA512/256",
                 CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512);
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -46,7 +46,7 @@ public final class P11Util {
 
     // Used by PBE
     static final class KDFData {
-        public enum Operation {ENCRYPTION, AUTHENTICATION, GENERIC}
+        public enum Operation {ENCRYPTION, AUTHENTICATION}
         public long kdfMech;
         public long prfMech;
         public String keyAlgo;
@@ -64,7 +64,7 @@ public final class P11Util {
         public static void addPbkdf2Data(String algo, long kdfMech,
                                          long prfMech) {
             kdfDataMap.put(algo, new KDFData(kdfMech, prfMech,
-                    algo, -1, Operation.GENERIC));
+                    algo, -1, Operation.AUTHENTICATION));
         }
 
         public static void addPbkdf2AesData(String algo, long kdfMech,

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -27,11 +27,6 @@ package sun.security.pkcs11;
 
 import java.math.BigInteger;
 import java.security.*;
-import java.util.HashMap;
-import java.util.Map;
-import sun.security.pkcs11.wrapper.CK_ATTRIBUTE;
-
-import static sun.security.pkcs11.wrapper.PKCS11Constants.*;
 
 /**
  * Collection of static utility methods.
@@ -44,93 +39,6 @@ public final class P11Util {
     private static Object LOCK = new Object();
 
     private static volatile Provider sun, sunRsaSign, sunJce;
-
-    // Used by PBE
-    static final class KDFData {
-        public final long kdfMech;
-        public final long prfMech;
-        public final String keyAlgo;
-        public final int keyLen;
-        public final CK_ATTRIBUTE encrypt_or_sign_true;
-
-        KDFData(long kdfMech, long prfMech, String keyAlgo,
-                int keyLen, CK_ATTRIBUTE encrypt_or_sign_true) {
-            this.kdfMech = kdfMech;
-            this.prfMech = prfMech;
-            this.keyAlgo = keyAlgo;
-            this.keyLen = keyLen;
-            this.encrypt_or_sign_true = encrypt_or_sign_true;
-        }
-
-        public static void addPbkdf2Data(String algo, long kdfMech,
-                                         long prfMech) {
-            kdfDataMap.put(algo, new KDFData(kdfMech, prfMech,
-                    algo, -1, CK_ATTRIBUTE.SIGN_TRUE));
-        }
-
-        public static void addPbkdf2AesData(String algo, long kdfMech,
-                                            long prfMech, int keyLen) {
-            kdfDataMap.put(algo, new KDFData(kdfMech, prfMech,
-                    "AES", keyLen, CK_ATTRIBUTE.ENCRYPT_TRUE));
-        }
-
-        public static void addPkcs12KDMacData(String algo, long kdfMech,
-                                              int keyLen) {
-            kdfDataMap.put(algo, new KDFData(kdfMech, -1,
-                    "HMAC", keyLen, CK_ATTRIBUTE.SIGN_TRUE));
-        }
-    }
-
-    static final Map<String, KDFData> kdfDataMap = new HashMap<>();
-
-    static {
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA1AndAES_128",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA1, 128);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA224AndAES_128",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA224, 128);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA256AndAES_128",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA256, 128);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA384AndAES_128",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA384, 128);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA512AndAES_128",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA512, 128);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA1AndAES_256",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA1, 256);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA224AndAES_256",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA224, 256);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA256AndAES_256",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA256, 256);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA384AndAES_256",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA384, 256);
-        KDFData.addPbkdf2AesData("PBEWithHmacSHA512AndAES_256",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA512, 256);
-
-        KDFData.addPbkdf2Data("PBKDF2WithHmacSHA1",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA1);
-        KDFData.addPbkdf2Data("PBKDF2WithHmacSHA224",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA224);
-        KDFData.addPbkdf2Data("PBKDF2WithHmacSHA256",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA256);
-        KDFData.addPbkdf2Data("PBKDF2WithHmacSHA384",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA384);
-        KDFData.addPbkdf2Data("PBKDF2WithHmacSHA512",
-                CKM_PKCS5_PBKD2, CKP_PKCS5_PBKD2_HMAC_SHA512);
-
-        KDFData.addPkcs12KDMacData("HmacPBESHA1",
-                CKM_PBA_SHA1_WITH_SHA1_HMAC, 160);
-        KDFData.addPkcs12KDMacData("HmacPBESHA224",
-                CKM_NSS_PKCS12_PBE_SHA224_HMAC_KEY_GEN, 224);
-        KDFData.addPkcs12KDMacData("HmacPBESHA256",
-                CKM_NSS_PKCS12_PBE_SHA256_HMAC_KEY_GEN, 256);
-        KDFData.addPkcs12KDMacData("HmacPBESHA384",
-                CKM_NSS_PKCS12_PBE_SHA384_HMAC_KEY_GEN, 384);
-        KDFData.addPkcs12KDMacData("HmacPBESHA512",
-                CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512);
-        KDFData.addPkcs12KDMacData("HmacPBESHA512/224",
-                CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512);
-        KDFData.addPkcs12KDMacData("HmacPBESHA512/256",
-                CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN, 512);
-    }
 
     private P11Util() {
         // empty

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -422,6 +422,7 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
                  case CKM_NSS_PKCS12_PBE_SHA256_HMAC_KEY_GEN:
                  case CKM_NSS_PKCS12_PBE_SHA384_HMAC_KEY_GEN:
                  case CKM_NSS_PKCS12_PBE_SHA512_HMAC_KEY_GEN:
+                     TRACE0("[ CK_PBE_PARAMS ]\n");
                      free(((CK_PBE_PARAMS_PTR)tmp)->pInitVector);
                      free(((CK_PBE_PARAMS_PTR)tmp)->pPassword);
                      free(((CK_PBE_PARAMS_PTR)tmp)->pSalt);

--- a/test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
@@ -138,13 +138,13 @@ final class PBECipher2 extends PKCS11Test {
                 + " (with " + conf.name() + ")");
 
         BigInteger cipherText = computeCipherText(sunPKCS11, algorithm, conf);
-        printByteArray("Cipher Text", cipherText);
+        printHex("Cipher Text", cipherText);
 
         BigInteger expectedCipherText =
                 computeExpectedCipherText(algorithm, conf);
 
         if (!cipherText.equals(expectedCipherText)) {
-            printByteArray("Expected Cipher Text", expectedCipherText);
+            printHex("Expected Cipher Text", expectedCipherText);
             throw new Exception("Expected Cipher Text did not match");
         }
     }
@@ -230,7 +230,7 @@ final class PBECipher2 extends PKCS11Test {
         };
     }
 
-    private static void printByteArray(String title, BigInteger b) {
+    private static void printHex(String title, BigInteger b) {
         String repr = (b == null) ? "buffer is null" : b.toString(16);
         System.out.println(title + ": " + repr + System.lineSeparator());
     }

--- a/test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
@@ -169,8 +169,7 @@ final class PBECipher2 extends PKCS11Test {
             }
             case SunPKCS11SecretKeyFactoryDerivedKey -> {
                 SecretKey key = getDerivedSecretKey(p, algorithm);
-                pbeCipher.init(Cipher.ENCRYPT_MODE, key,
-                        p == sunJCE ? pbeSpec : ivSpec);
+                pbeCipher.init(Cipher.ENCRYPT_MODE, key, ivSpec);
             }
             case AnonymousPBEKey -> {
                 SecretKey key = getPasswordSaltIterationsPBEKey();

--- a/test/jdk/sun/security/pkcs11/KeyStore/ImportKeyToP12.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/ImportKeyToP12.java
@@ -69,8 +69,8 @@ final class ImportKeyToP122 extends PKCS11Test {
             "HmacPBESHA384", "HmacPBESHA512"
     };
     private static final KeyStore p12;
-    private static final String sep =
-    "=========================================================================";
+    private static final String sep = "======================================" +
+            "===================================";
 
     static {
         KeyStore tP12 = null;
@@ -128,7 +128,8 @@ final class ImportKeyToP122 extends PKCS11Test {
         if (!MessageDigest.isEqual(key.getEncoded(), k.getEncoded())) {
             throw new Exception("Keys differ. Consistency check failed.");
         }
-        System.out.println("Secret key import successful" + System.lineSeparator() + sep);
+        System.out.println("Secret key import successful"
+                + System.lineSeparator() + sep);
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/security/pkcs11/Mac/MacSameTest.java
+++ b/test/jdk/sun/security/pkcs11/Mac/MacSameTest.java
@@ -42,6 +42,8 @@ import java.util.List;
 import javax.crypto.Mac;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
 public class MacSameTest extends PKCS11Test {
@@ -75,9 +77,18 @@ public class MacSameTest extends PKCS11Test {
             // first try w/ java secret key object
             byte[] keyVal = new byte[KEY_SIZE];
             srdm.nextBytes(keyVal);
-            SecretKey skey = new SecretKeySpec(keyVal, alg);
-
+            SecretKey skey;
             try {
+                if (alg.startsWith("HmacPBE")) {
+                    char[] pwd = new char[keyVal.length];
+                    for (int i = 0; i < keyVal.length; i++) {
+                        pwd[i] = (char) keyVal[i];
+                    }
+                    skey = SecretKeyFactory.getInstance(alg, p).generateSecret(
+                            new PBEKeySpec(pwd, keyVal, 1000));
+                } else {
+                    skey = new SecretKeySpec(keyVal, alg);
+                }
                 doTest(alg, skey, p);
             } catch (Exception e) {
                 System.out.println("Unexpected exception: " + e);

--- a/test/jdk/sun/security/pkcs11/Mac/PBAMac.java
+++ b/test/jdk/sun/security/pkcs11/Mac/PBAMac.java
@@ -108,12 +108,12 @@ final class PBAMac2 extends PKCS11Test {
                 + " (with " + conf.name() + ")");
 
         BigInteger macResult = computeMac(sunPKCS11, algorithm, conf);
-        printByteArray("HMAC Result", macResult);
+        printHex("HMAC Result", macResult);
 
         BigInteger expectedMacResult = computeExpectedMac(algorithm, conf);
 
         if (!macResult.equals(expectedMacResult)) {
-            printByteArray("Expected HMAC Result", expectedMacResult);
+            printHex("Expected HMAC Result", expectedMacResult);
             throw new Exception("Expected HMAC Result did not match");
         }
     }
@@ -183,7 +183,7 @@ final class PBAMac2 extends PKCS11Test {
         };
     }
 
-    private static void printByteArray(String title, BigInteger b) {
+    private static void printHex(String title, BigInteger b) {
         String repr = (b == null) ? "buffer is null" : b.toString(16);
         System.out.println(title + ": " + repr + System.lineSeparator());
     }

--- a/test/jdk/sun/security/pkcs11/Mac/ReinitMac.java
+++ b/test/jdk/sun/security/pkcs11/Mac/ReinitMac.java
@@ -37,6 +37,9 @@ import java.security.Provider;
 import java.util.Random;
 import java.util.List;
 import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
 public class ReinitMac extends PKCS11Test {
@@ -75,7 +78,17 @@ public class ReinitMac extends PKCS11Test {
     private void doTest(String alg, Provider p, byte[] keyVal, byte[] data)
             throws Exception {
         System.out.println("Testing " + alg);
-        SecretKeySpec key = new SecretKeySpec(keyVal, alg);
+        SecretKey key;
+        if (alg.startsWith("HmacPBE")) {
+            char[] pwd = new char[keyVal.length];
+            for (int i = 0; i < keyVal.length; i++) {
+                pwd[i] = (char) keyVal[i];
+            }
+            key = SecretKeyFactory.getInstance(alg, p).generateSecret(
+                    new PBEKeySpec(pwd, keyVal, 1000));
+        } else {
+            key = new SecretKeySpec(keyVal, alg);
+        }
         Mac mac = Mac.getInstance(alg, p);
         mac.init(key);
         mac.init(key);

--- a/test/jdk/sun/security/pkcs11/SecretKeyFactory/TestPBKD.java
+++ b/test/jdk/sun/security/pkcs11/SecretKeyFactory/TestPBKD.java
@@ -295,12 +295,12 @@ final class TestPBKD2 extends PKCS11Test {
             case AnonymousPBEKey -> skFac.translateKey(key);
         };
         BigInteger derivedKey = new BigInteger(1, derivedKeyObj.getEncoded());
-        printByteArray("Derived Key", derivedKey);
+        printHex("Derived Key", derivedKey);
 
         BigInteger expectedDerivedKey = assertData.derive(algorithm, keySpec);
 
         if (!derivedKey.equals(expectedDerivedKey)) {
-            printByteArray("Expected Derived Key", expectedDerivedKey);
+            printHex("Expected Derived Key", expectedDerivedKey);
             throw new Exception("Expected Derived Key did not match");
         }
     }
@@ -316,7 +316,7 @@ final class TestPBKD2 extends PKCS11Test {
         };
     }
 
-    private static void printByteArray(String title, BigInteger b) {
+    private static void printHex(String title, BigInteger b) {
         String repr = (b == null) ? "buffer is null" : b.toString(16);
         System.out.println(title + ": " + repr + System.lineSeparator());
     }


### PR DESCRIPTION
# [RH2130351: SunPKCS11 PBE API Enhancements](https://bugzilla.redhat.com/show_bug.cgi?id=2130351)

As part of the work for [RHELPLAN-112612](https://issues.redhat.com/browse/RHELPLAN-112612 "Support PKCS#12 keystores in FIPS mode") we implemented support for the following PBE algorithms in _SunPKCS11_:

| _Algorithm name_                | _Derivation_ | `Mac` | `Cipher` | `SecretKeyFactory` |
|:--------------------------------|:-------------|:-----:|:--------:|:------------------:|
| `"PBEWithHmacSHA1AndAES_128"`   | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA224AndAES_128"` | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA256AndAES_128"` | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA384AndAES_128"` | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA512AndAES_128"` | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA1AndAES_256"`   | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA224AndAES_256"` | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA256AndAES_256"` | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA384AndAES_256"` | new (PBKDF2) |       |    x     |         x          |
| `"PBEWithHmacSHA512AndAES_256"` | new (PBKDF2) |       |    x     |         x          |
| `"HmacPBESHA1"`                 | old (PKCS12) |   x   |          |         x          |
| `"HmacPBESHA224"`               | old (PKCS12) |   x   |          |         x          |
| `"HmacPBESHA256"`               | old (PKCS12) |   x   |          |         x          |
| `"HmacPBESHA384"`               | old (PKCS12) |   x   |          |         x          |
| `"HmacPBESHA512"`               | old (PKCS12) |   x   |          |         x          |
| `"HmacPBESHA512/224"`           | old (PKCS12) |   x   |          |         x          |
| `"HmacPBESHA512/256"`           | old (PKCS12) |   x   |          |         x          |
| `"PBKDF2WithHmacSHA1"`          | new (PBKDF2) |       |          |         x          |
| `"PBKDF2WithHmacSHA224"`        | new (PBKDF2) |       |          |         x          |
| `"PBKDF2WithHmacSHA256"`        | new (PBKDF2) |       |          |         x          |
| `"PBKDF2WithHmacSHA384"`        | new (PBKDF2) |       |          |         x          |
| `"PBKDF2WithHmacSHA512"`        | new (PBKDF2) |       |          |         x          |

Since _SunJCE_ `SecretKeyFactory` implementations are allowed in FIPS (they don't perform any cryptographic operation) we also left them enabled. A _SunJCE_ `SecretKeyFactory` implementation is [used by the PKCS#12 keystore code](https://github.com/openjdk/jdk17u/blob/jdk-17.0.4-ga/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java#L860-L877), through the [`"PBE"` → `"PBEWithMD5AndDES"` alias](https://github.com/openjdk/jdk17u/blob/jdk-17.0.4-ga/src/java.base/share/classes/sun/security/util/SecurityProviderConstants.java#L216), because `"PBEWithMD5AndDES"` was not implemented in _SunPKCS11_.

We decided to implement `SecretKeyFactory` services in _SunPKCS11_ (for the algorithms already implemented in other services) in the sake of completeness, and thinking in the PBE upstream proposal we are planning to do. Also, we decided that those `SecretKeyFactory` services should perform key derivation, as with _SunJCE_'s `"PBKDF2*"` secret key factories, despite the following _SunJCE_ behavior:

* `"HmacPBE*"` secret key factories don't exist in _SunJCE_
* `"PBEWithHmac*And*"` secret key factories don't perform derivation, they [just put the password into a _SunJCE_ password-only `PBEKey` (any salt or iterations count value from the `PBEKeySpec` is lost)](https://github.com/openjdk/jdk17u/blob/jdk-17.0.4-ga/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java#L61)

During the analyses performed for some behaviours documented in [OPENJDK-991](https://issues.redhat.com/browse/OPENJDK-991 "Missing KeyGenerators for newly appeared algorithms in SecretKeyFactory in FIPS mode") (in the comments), we determined that we need some improvements for _SunPKCS11_ `SecretKeyFactory` implementations to be finished and properly interoperable:

* `"*"` secret key factories (all):
  * Special invalid `PBEKeySpec` corner cases in `::generateSecret()` (avoid a JNI call into the PKCS#11 token that we know will fail)
    * If `itCount < 1`, throw `InvalidKeySpecException: Iteration count must be a non-zero positive integer`
    * If `keySize < 1`, throw `InvalidKeySpecException: Key length must be a non-zero positive integer`
    * If `keySize % 8 != 0`, throw `InvalidKeySpecException: Key length (in bits) must be an 8 multiple`
  * Review and re-think `::translateKey()`
    * Avoid a [`NullPointerException` when an unrelated-algorithm `SecretKeyFactory` is asked to translate a `PBEKey`](https://github.com/rh-openjdk/jdk/blob/1e26894969d911776f60eaa557d25a2b389060da/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java#L206)
    * Identify PBE `SecretKey` instances from the own `SecretKeyFactory` and return them untranslated
    * Try to enable interoperation with other providers' implementations of `javax.crypto.interfaces.PBEKey`, as long as they have all the required information (_SunJCE_ password-only `com.sun.crypto.provider.PBEKey` doesn't implement this interface)
* `"PBKDF2*"` secret key factories:
  * Generated keys should keep the original algorithm (currently, they use `"Generic"`), although the underlying key type will still be `CKK_GENERIC_SECRET`
  * Those generated keys only work in `Mac` algorithms and won't work with `Cipher` algorithms
    * This is because, for the case that concerns us, [NSS expects `CKK_AES`](https://github.com/nss-dev/nss/blob/NSS_3_67_RTM/lib/softoken/pkcs11c.c#L1240-L1243), so we should stop giving the `CKA_ENCRYPT` attribute to the key in vain (see [`P11Util.java:64-68`](https://github.com/rh-openjdk/jdk/blob/1e26894969d911776f60eaa557d25a2b389060da/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java#L64-L68) and [`P11SecretKeyFactory.java:282-285`](https://github.com/rh-openjdk/jdk/blob/1e26894969d911776f60eaa557d25a2b389060da/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java#L282-L285))
    * This is fine, since _SunJCE_ `"PBKDF2*"` keys don't work either in their `Mac` nor `Cipher` services, the common use case seems to be just calling `key.getEncoded()` to get the derived key bytes (which can also be considered as a salted hash of the password)
* `"HmacPBE*"` & `"PBEWithHmac*And*"` secret key factories:
  * Try to maintain the original algorithm as the key algorithm (currently, we use `"Generic"` & `"AES"` respectively)
  * Generated keys, which are already derived, should work in `Mac` & `Cipher` services for the exact same algorithm
    * Currently, this doesn't work, we need to skip the key derivation in such cases

The goal of this enhancement is to implement the aforementioned improvements, including any required test adjustment, and creating new test cases for `SecretKeyFactory` + `Cipher` and `SecretKeyFactory` + `Mac` use cases.