### PR TITLE
Remove forgotten dead code from #13 and #14

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -32,7 +32,6 @@ import java.security.cert.*;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.net.ssl.*;
-import jdk.internal.access.SharedSecrets;
 import sun.security.action.GetPropertyAction;
 import sun.security.provider.certpath.AlgorithmChecker;
 import sun.security.validator.Validator;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/FIPSKeyImporter.java
@@ -72,9 +72,6 @@ final class FIPSKeyImporter {
     private static volatile Provider sunECProvider = null;
     private static final ReentrantLock sunECProviderLock = new ReentrantLock();
 
-    private static volatile KeyFactory DHKF = null;
-    private static final ReentrantLock DHKFLock = new ReentrantLock();
-
     static Long importKey(SunPKCS11 sunPKCS11, long hSession, CK_ATTRIBUTE[] attributes)
             throws PKCS11Exception {
         long keyID = -1;
@@ -319,8 +316,7 @@ final class FIPSKeyImporter {
                     CKA_PRIVATE_EXPONENT, CKA_PRIME_1, CKA_PRIME_2,
                     CKA_EXPONENT_1, CKA_EXPONENT_2, CKA_COEFFICIENT);
             RSAPrivateKey rsaPKey = RSAPrivateCrtKeyImpl.newKey(
-                    RSAUtil.KeyType.RSA, "PKCS#8", plainExportedKey
-            );
+                    RSAUtil.KeyType.RSA, "PKCS#8", plainExportedKey);
             CK_ATTRIBUTE attr;
             if ((attr = sensitiveAttrs.get(CKA_PRIVATE_EXPONENT)) != null) {
                 attr.pValue = rsaPKey.getPrivateExponent().toByteArray();


### PR DESCRIPTION
# Remove forgotten dead code from #13 and #14

#13 isn't a perfect revert of 0af22dcc391ff38f65ff7d7cfcc2f933e29e9126 limited to `SSLContextImpl.java` and `SunJSSE.java`, since it doesn't remove the `SharedSecrets` import. This was already in this way in [`rh2020290-support_tls_1_3_in_fips.v1.patch`](https://bugzilla.redhat.com/attachment.cgi?id=1841886&action=diff), I'm now realizing this when doing the OpenJDK 11 backport (rh-openjdk/jdk11u#7) and retrying the same approach in OpenJDK 17:

```shell
# Revert #13
git show 0bd5ca9ccc5890b009b927b541424d0aacbb0463 | git apply -R
# Redo #13 by reverting 0af22dc in SSLContextImpl.java and SunJSSE.java
git show 0af22dcc391ff38f65ff7d7cfcc2f933e29e9126 |
  git apply -R --include=src/java.base/share/classes/sun/security/ssl/*
```

----

In #14, I forgot to delete the `DHKF` and `DHKFLock` static variables from `FIPSKeyImporter`, which are no longer used, see [this #14 comment](https://github.com/rh-openjdk/jdk/pull/14/files#r1003709626).