### PR TITLE
RH1940064: Enable XML Signature provider in FIPS mode

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -88,6 +88,7 @@ fips.provider.3=SunEC
 fips.provider.4=SunJSSE
 fips.provider.5=SunJCE
 fips.provider.6=SunRsaSign
+fips.provider.7=XMLDSig
 
 #
 # A list of preferred providers for specific algorithms. These providers will


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/24"))_

# [RH1940064: Enable XML Signature provider in FIPS mode](https://bugzilla.redhat.com/show_bug.cgi?id=1940064)

A pull request for [RH2156945: Enable XML Signature provider in FIPS mode [rhel-8, openjdk-17]](https://bugzilla.redhat.com/show_bug.cgi?id=2156945). This work depends on the lock-down of disallowed algorithms from non-FIPS providers (765baf2fac0269f28907736a1e971aad15ec7a7a, 6e74f283739af0d867df01d20f82865f559a45ea, #1, #5, #16, #19).

In order to enable the _XMLDSig_ security provider, we must add the following line to `java.security`:

```
fips.provider.7=XMLDSig
```

## Notes

I have been reviewing [`org.jcp.xml.dsig.internal.dom.XMLDSigRI`](/openjdk/jdk17u/blob/jdk-17.0.5-ga/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/XMLDSigRI.java#L49 "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/XMLDSigRI.java"), the implementation of the _XMLDSig_ provider, and it seems to use JCA generic APIs, allowing us to provide all the cryptographic operations through _SunPKCS11_ (the only provider allowed for such operations when in FIPS-mode, for compliance reasons).

The following `DOMSignContext` / `DOMValidateContext` properties accept a `Provider` instance to use cryptographic operations from it:

* [`org.jcp.xml.dsig.internal.dom.MacProvider`](/openjdk/jdk17u/blob/jdk-17.0.5-ga/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMHMACSignatureMethod.java#L54 "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMHMACSignatureMethod.java:54")
* [`org.jcp.xml.dsig.internal.dom.SignatureProvider`](/openjdk/jdk17u/blob/jdk-17.0.5-ga/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMSignatureMethod.java#L53 "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMSignatureMethod.java:53")

Although these properties seem to be unknown / undocumented, there is a usage sample in _Apache Santuario_ tests, in [`src/test/java/javax/xml/crypto/test/dsig/XMLSignatureTest.java:194-229`](/apache/santuario-java/blob/xmlsec-2.1.5/src/test/java/javax/xml/crypto/test/dsig/XMLSignatureTest.java#L194-L229).

However, we don't need to remove these properties, since a user that tries to pass them while in FIPS-mode, is in one of the following scenarios:

* They pass a _SunPKCS11_ `Provider` instance (this is fine)
* They pass a _SunJCE_ `Provider` instance (_SunJCE_ has the lock-down in place, so any cryptographic operation is removed, and the user will face an error at some point)
* They add another custom provider to the FIPS configuration in `java.security`, and pass an instance of that `Provider` (this is unsupported, and we can't assert their configuration is FIPS compliant, regardless of the `DOMSignContext` / `DOMValidateContext` properties usage)

After editing `java.security` to enable the _XMLDSig_ provider, I executed the [`XMLDSigWithSecMgr` test](/openjdk/jdk17u/blob/jdk-17.0.5-ga/test/jdk/javax/xml/crypto/dsig/SecurityManager/XMLDSigWithSecMgr.java#L26-L28) in a _RHEL_ VM configured in FIPS-mode. Then I confirmed through debugging that _SunPKCS11_ is being used for _digest_, _sign_ and _verify_ operations.

Finally, I also checked for direct instantiation of provider classes, such as that which caused #16, in [`sun.security.pkcs11.P11Util.getSunJceProvider()`](/openjdk/jdk17u/blob/jdk-17.0.5-ga/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java#L71-L116 "src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java:71-116"). I was unable to spot any direct usage of _SunJCE_, which would cause errors due to removed algorithms in FIPS.