### PR TITLE
RH2173781: Avoid calling C_GetInfo() too early, before cryptoki is initialized

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -220,9 +220,11 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
             }
 
             if (kdfData.kdfMech == CKM_PKCS5_PBKD2) {
-                CK_VERSION p11Ver = token.p11.getInfo().cryptokiVersion;
-                if (P11Util.isNSS(token) || p11Ver.major < 2 ||
-                        p11Ver.major == 2 && p11Ver.minor < 40) {
+                CK_INFO p11Info = token.p11.getInfo();
+                CK_VERSION p11Ver = (p11Info != null ? p11Info.cryptokiVersion
+                        : null);
+                if (P11Util.isNSS(token) || p11Ver != null && (p11Ver.major <
+                        2 || p11Ver.major == 2 && p11Ver.minor < 40)) {
                     // NSS keeps using the old structure beyond PKCS #11 v2.40
                     ckMech = new CK_MECHANISM(kdfData.kdfMech,
                             new CK_PKCS5_PBKD2_PARAMS(password, salt,

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -153,7 +153,7 @@ public class PKCS11 {
             throws IOException, PKCS11Exception {
         connect(pkcs11ModulePath, functionListName);
         this.pkcs11ModulePath = pkcs11ModulePath;
-        pInfo = C_GetInfo();
+        pInfo = null;
     }
 
     /*
@@ -215,6 +215,12 @@ public class PKCS11 {
      * C_GetInfo. This structure represent Cryptoki library information.
      */
     public CK_INFO getInfo() {
+        if (pInfo == null) {
+            try {
+                pInfo = C_GetInfo();
+            } catch (PKCS11Exception e) {
+            }
+        }
         return pInfo;
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -116,7 +116,7 @@ public class PKCS11 {
 
     private long pNativeData;
 
-    private CK_INFO pInfo;
+    private volatile CK_INFO pInfo;
 
     /**
      * This method does the initialization of the native library. It is called
@@ -153,7 +153,6 @@ public class PKCS11 {
             throws IOException, PKCS11Exception {
         connect(pkcs11ModulePath, functionListName);
         this.pkcs11ModulePath = pkcs11ModulePath;
-        pInfo = null;
     }
 
     /*
@@ -215,13 +214,21 @@ public class PKCS11 {
      * C_GetInfo. This structure represent Cryptoki library information.
      */
     public CK_INFO getInfo() {
-        if (pInfo == null) {
-            try {
-                pInfo = C_GetInfo();
-            } catch (PKCS11Exception e) {
+        CK_INFO lPInfo = pInfo;
+        if (lPInfo == null) {
+            synchronized (this) {
+                lPInfo = pInfo;
+                if (lPInfo == null) {
+                    try {
+                        lPInfo = C_GetInfo();
+                        pInfo = lPInfo;
+                    } catch (PKCS11Exception e) {
+                        // Some PKCS #11 tokens require initialization first.
+                    }
+                }
             }
         }
-        return pInfo;
+        return lPInfo;
     }
 
     /**


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/26"))_

The call of C_GetInfo() in the PKCS11 class constructor is too early, since that function needs cryptoki initialized. This patch fixes this issue. And it still uses the pInfo structure instead of calling C_GetInfo zillion times.

I think that the fix is right. At least it solved here issues I saw. But I might be utterly wrong ;)