### PR TITLE
test/jdk/sun/security/pkcs11/fips/VerifyMissingAttributes.java: fixed jtreg main class

### DIFF
--- a/test/jdk/sun/security/pkcs11/fips/VerifyMissingAttributes.java
+++ b/test/jdk/sun/security/pkcs11/fips/VerifyMissingAttributes.java
@@ -29,7 +29,7 @@ import java.security.Security;
  * @test
  * @bug 9999999
  * @requires (jdk.version.major >= 8)
- * @run main/othervm/timeout=30 Main
+ * @run main/othervm/timeout=30 VerifyMissingAttributes
  * @author Martin Balao (mbalao@redhat.com)
  */
 


### PR DESCRIPTION
Test `test/jdk/sun/security/pkcs11/fips/VerifyMissingAttributes.java` currently ends with error, when ran as jtreg, due to incorrect class name in `@run` tag. Tested, test passes with this fix on rhel8+fips.