### PR TITLE
Tools.gmk: Add annobin GCC plugin

### DIFF
--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -475,7 +475,7 @@ $(BUILDDIR)/$(binutils_ver)/Makefile \
 	      --enable-multilib \
 	      --enable-threads \
 	      --enable-plugins \
-	) 2>&1 | tee $(@D)/log.config 
+	) 2>&1 | tee $(@D)/log.config
 	@echo 'done'
 
 $(BUILDDIR)/$(mpfr_ver)/Makefile \
@@ -544,7 +544,7 @@ ifneq (,$(annobin_ver))
 	      --without-debuginfod \
 	      --without-clang-plugin \
 	      --without-llvm-plugin \
-	) > $(@D)/log.config 2>&1
+	) 2>&1 | tee $(@D)/log.config
 	@echo 'done'
 endif
 

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -195,6 +195,10 @@ MPFR := https://www.mpfr.org/${mpfr_ver}/${mpfr_ver}.tar.bz2
 GMP := http://ftp.gnu.org/pub/gnu/gmp/${gmp_ver}.tar.bz2
 MPC := http://ftp.gnu.org/pub/gnu/mpc/${mpc_ver}.tar.gz
 GDB := http://ftp.gnu.org/gnu/gdb/${gdb_ver}.tar.xz
+ifneq (,$(annobin_ver))
+  ANNOBIN := https://nickc.fedorapeople.org/$(annobin_ver).tar.xz
+  gcc_ver_only := $(patsubst gcc-%,%,$(gcc_ver))
+endif
 
 # RPMs used by all BASE_OS
 RPM_LIST := \
@@ -280,7 +284,7 @@ define Download
 endef
 
 # Download and unpack all source packages
-$(foreach p,GCC BINUTILS CCACHE MPFR GMP MPC GDB,$(eval $(call Download,$(p))))
+$(foreach p,GCC BINUTILS CCACHE MPFR GMP MPC GDB $(if $(annobin_ver),ANNOBIN),$(eval $(call Download,$(p))))
 
 ##########################################################################################
 # Unpack RPMS
@@ -360,7 +364,7 @@ endif
 ##########################################################################################
 
 # Define marker files for each source package to be compiled
-$(foreach t,binutils mpfr gmp mpc gcc ccache gdb,$(eval $(t) = $(TARGETDIR)/$($(t)_ver).done))
+$(foreach t,binutils mpfr gmp mpc gcc ccache gdb $(if $(annobin_ver),annobin),$(eval $(t) = $(TARGETDIR)/$($(t)_ver).done))
 
 ##########################################################################################
 
@@ -432,6 +436,7 @@ $(gcc) \
     $(mpfr) \
     $(mpc) \
     $(bfdmakes) \
+    $(if $(annobin_ver),$(annobin)) \
     $(ccache) : ENVS += $(TOOLS)
 
 # libdir to work around hateful bfd stuff installing into wrong dirs...
@@ -521,6 +526,28 @@ $(BUILDDIR)/$(mpc_ver)/Makefile \
 	) 2>&1 | tee $(@D)/log.config
 	@echo 'done'
 
+ifneq (,$(annobin_ver))
+  $(BUILDDIR)/$(annobin_ver)/Makefile \
+    : $(ANNOBIN_CFG)
+	$(info Configuring $@. Log in $(@D)/log.config)
+	@mkdir -p $(@D)
+	( \
+	  cd $(@D) ; \
+	  $(PATHPRE) $(ENVS) CFLAGS="$(CFLAGS) -I$(PREFIX)/include" CXXFLAGS="$(CFLAGS) -I$(PREFIX)/include" \
+	      $(ANNOBIN_CFG) \
+	      $(CONFIG) \
+	      --with-gcc-plugin-dir=$(PREFIX)/lib/gcc/$(TARGET)/$(gcc_ver_only)/plugin \
+	      --without-annocheck \
+	      --without-tests \
+	      --without-docs \
+	      --disable-rpath \
+	      --without-debuginfod \
+	      --without-clang-plugin \
+	      --without-llvm-plugin \
+	) > $(@D)/log.config 2>&1
+	@echo 'done'
+endif
+
 # Only valid if glibc target -> linux
 # proper destructor handling for c++
 ifneq (,$(findstring linux,$(TARGET)))
@@ -574,6 +601,10 @@ $(gcc) : $(binutils)
 $(BUILDDIR)/$(gcc_ver)/Makefile : $(gmp) $(mpfr) $(mpc)
 $(mpfr) : $(gmp)
 $(mpc) : $(gmp) $(mpfr)
+
+ifneq (,$(annobin_ver))
+  $(annobin) : $(gcc) $(gmp)
+endif
 
 ################################################################################
 # Build gdb but only where host and target match
@@ -718,10 +749,13 @@ libs : $(libs)
 sysroot : rpms libs
 gcc : sysroot $(gcc) $(gccpatch)
 gdb : $(gdb)
+ifneq (,$(annobin_ver))
+  annobin : $(annobin)
+endif
 all : binutils gcc bfdlib $(PREFIX)/devkit.info $(missing-links) $(SYSROOT_LINKS) \
-    $(THESE_MAKEFILES) gdb
+    $(THESE_MAKEFILES) gdb $(if $(annobin_ver),annobin)
 
 # this is only built for host. so separate.
 ccache : $(ccache)
 
-.PHONY : gcc all binutils bfdlib link_libs rpms libs sysroot
+.PHONY : gcc all binutils bfdlib link_libs rpms libs sysroot $(if $(annobin_ver),annobin)


### PR DESCRIPTION
This patch builds `annobin.so.0.0.0` and installs it to the `GCC` plugins directory of the devkit.  `annobin.so.0.0.0` is built with the same `CFLAGS`, `CXXFLAGS` and `LDFLAGS` as other target libraries like `gmp`.

I only tested on the `GCC` `11.3.0` devkit, so throughout `Tools.gmk` I made `annobin` logic conditional on `annobin_ver` being set.

Tested on `x86-64` and `ppc64le` `Fedora 42` (example `ppc64le` run follows):

```
[root@fedora tmp]$ export PATH=/opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/bin:$PATH
[root@fedora tmp]$ export LD_LIBRARY_PATH=/opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/lib64
[root@fedora tmp]$ ldd /opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/lib/gcc/ppc64le-linux-gnu/11.3.0/plugin/annobin.so.0.0.0
	linux-vdso64.so.1 (0x00007fffa79c0000)
	libstdc++.so.6 => /opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/lib64/libstdc++.so.6 (0x00007fffa7600000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fffa74b0000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fffa7200000)
	libgcc_s.so.1 => /opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/lib64/libgcc_s.so.1 (0x00007fffa7900000)
	/lib64/ld64.so.2 (0x00007fffa79d0000)
[root@fedora tmp]$ type -P gcc
/opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/bin/gcc
[root@fedora tmp]$ cat > test.c <<EOF
#include <stdio.h>

int main()
{
  printf("Hello, World!\n");
  return 0;
}
EOF
[root@fedora tmp]$ strace -f -e openat gcc -fplugin=annobin -Wall -o test.anno test.c 2>&1 | grep annobin.so
[pid  1870] openat(AT_FDCWD, "/opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/bin/../lib/gcc/ppc64le-linux-gnu/11.3.0/plugin/annobin.so", O_RDONLY|O_CLOEXEC) = 3
[root@fedora tmp]$ readlink -f /opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/bin/../lib/gcc/ppc64le-linux-gnu/11.3.0/plugin/annobin.so
/opt/devkit/ppc64le-linux-gnu-to-ppc64le-linux-gnu/lib/gcc/ppc64le-linux-gnu/11.3.0/plugin/annobin.so.0.0.0
[root@fedora tmp]$ gcc -fplugin=annobin -Wall -o test test.c
[root@fedora tmp]$ objdump -x test | grep annobin
 27 .annobin.notes 000000a4  0000000000000000  0000000000000000  0001013b  2**0
[root@fedora tmp]$ gcc -Wall -o test test.c
[root@fedora tmp]$ objdump -x test | grep annobin
[root@fedora tmp]$
```
