### PR TITLE
OPENJDK-4013: Update nss.fips.cfg to grant CKA_SIGN and CKA_ENCRYPT to any CKO_SECRET_KEY

### DIFF
--- a/src/java.base/share/conf/security/nss.fips.cfg.in
+++ b/src/java.base/share/conf/security/nss.fips.cfg.in
@@ -4,5 +4,5 @@ nssSecmodDirectory = ${fips.nssdb.path}
 nssDbMode = readWrite
 nssModule = fips
 
-attributes(*,CKO_SECRET_KEY,CKK_GENERIC_SECRET)={ CKA_SIGN=true }
+attributes(*,CKO_SECRET_KEY,*)={ CKA_SIGN=true CKA_ENCRYPT=true }
 


### PR DESCRIPTION
_[Search this PR in Red Hat Jira](https://issues.redhat.com/issues/?jql=issueFunction%20in%20linkedIssuesOfRemote(url,"https://github.com/rh-openjdk/jdk/pull/38"))_

Hi,

This pull request addresses [OPENJDK-4013: Update nss.fips.cfg to grant CKA_SIGN and CKA_ENCRYPT to any CKO_SECRET_KEY](https://issues.redhat.com/browse/OPENJDK-4013).

In particular, it applies to the following RHEL issues:
  * [RHEL-122121: Update nss.fips.cfg to grant CKA_SIGN and CKA_ENCRYPT to any CKO_SECRET_KEY \[rhel-9, openjdk-21\]](https://issues.redhat.com/browse/RHEL-122121)
  * [RHEL-TBD: Update nss.fips.cfg to grant CKA_SIGN and CKA_ENCRYPT to any CKO_SECRET_KEY \[rhel-8, openjdk-21\]](https://issues.redhat.com/browse/RHEL-TBD)

The change has been successfully tested by the Cryostat team, and is in production for them, see cryostatio/cryostat#932.