### PR TITLE
OPENJDK-4397: Update nss.fips.cfg to grant CKA_SIGN and CKA_ENCRYPT to any CKO_SECRET_KEY

### DIFF
--- a/src/java.base/share/conf/security/nss.fips.cfg.in
+++ b/src/java.base/share/conf/security/nss.fips.cfg.in
@@ -4,5 +4,5 @@ nssSecmodDirectory = ${fips.nssdb.path}
 nssDbMode = readWrite
 nssModule = fips
 
-attributes(*,CKO_SECRET_KEY,CKK_GENERIC_SECRET)={ CKA_SIGN=true }
+attributes(*,CKO_SECRET_KEY,*)={ CKA_SIGN=true CKA_ENCRYPT=true }
 


### PR DESCRIPTION
Rebase of https://github.com/rh-openjdk/jdk/pull/38 after 21.0.10 merge (https://github.com/rh-openjdk/jdk/pull/41)