### PR TITLE
OPENJDK-4559: Red Hat Build of OpenJDK 25 should not restrict all the providers in FIPS

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1207,9 +1207,7 @@ public abstract class Provider extends Properties {
     private static final class RedHatFIPSFilter {
         static final boolean IS_ON = Boolean.parseBoolean(
                 Security.getProperty("__redhat_fips_filter__"));
-        private static final Set<String> ANY_SERVICE_TYPE = Set.of();
         private static final Map<String, Set<String>> ALLOW_LIST = Map.of(
-                "SunPKCS11-FIPS", ANY_SERVICE_TYPE,
                 "SUN", Set.of(
                         "AlgorithmParameterGenerator",
                         "AlgorithmParameters", "CertificateFactory",
@@ -1217,21 +1215,18 @@ public abstract class Provider extends Properties {
                         "Configuration", "KeyStore"),
                 "SunEC", Set.of(
                         "AlgorithmParameters", "KeyFactory"),
-                "SunJSSE", ANY_SERVICE_TYPE,
                 "SunJCE", Set.of(
                         "AlgorithmParameters",
                         "AlgorithmParameterGenerator", "KeyFactory",
                         "SecretKeyFactory"),
                 "SunRsaSign", Set.of(
-                        "KeyFactory", "AlgorithmParameters"),
-                "XMLDSig", ANY_SERVICE_TYPE
+                        "KeyFactory", "AlgorithmParameters")
         );
 
         static boolean isAllowed(String provName, String serviceType) {
             Set<String> allowedServiceTypes = ALLOW_LIST.get(provName);
-            return allowedServiceTypes != null &&
-                    (allowedServiceTypes == ANY_SERVICE_TYPE ||
-                            allowedServiceTypes.contains(serviceType));
+            return allowedServiceTypes == null ||
+                    allowedServiceTypes.contains(serviceType);
         }
     }
     /* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FIPS PATCH ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ */


### PR DESCRIPTION
# [OPENJDK-4559: Red Hat Build of OpenJDK 25 should not restrict all the providers in FIPS](https://issues.redhat.com/browse/OPENJDK-4559)

Hi,

This pull request addresses the problem described in [OPENJDK-4559](https://issues.redhat.com/browse/OPENJDK-4559 "Red Hat Build of OpenJDK 25 should not restrict all the providers in FIPS").

The `RedHatFIPSFilter` implemented by df044414ef4b53f88b03bf9bc1eea8d3c090db6b in `fips-25u` is too restrictive. This change restores the `fips-21u` behavior, where the user is allowed to insert _security providers_ without any validation. Otherwise, the user has no alternative when they need to use a third-party _security provider_.

## Testing

I locally built a release image from the sources, and applied the [`create-redhat-properties-files.bash`](https://gitlab.com/redhat/centos-stream/rpms/java-25-openjdk/-/blob/c10s/create-redhat-properties-files.bash) setup (with a local build of [nssadapter v0.1.1](https://github.com/rh-openjdk/nss-native-fips-key-import-export-adapter/releases/tag/0.1.1)), then copied the image to a RHEL 9 VM with FIPS-mode enabled.

### Manual execution of a simple PKCS #<span>12</span> keystore test

```bash
# Non-ASCII password
password='Th1s is a Bullet: •'

# Create a PKCS #12 keystore with a certificate and a key pair
openssl req -x509 -nodes -newkey rsa:4096 -subj /C=TT/ST=TT/L=TT/O=Test/CN=test.com/ -keyout key.pem -out cert.pem
openssl pkcs12 -export -inkey key.pem -in cert.pem -passout "pass:$password" -out ks.p12

# Read the keystore with keytool, enabling nssadapter and JCA logs
NSS_ADAPTER_DEBUG=color keytool -J-Djava.security.debug=all -list -storetype pkcs12 -keystore ks.p12 -storepass "$password"

# Cleanup
unset password && rm -f ks.p12 key.pem cert.pem
```

`nssadapter` is being used (we can see its log messages). This shows that _SunPKCS11_, despite no longer being part of the patch, is being allowed, as would any other third-party _provider_.

`RedHatFIPSFilter` messages are also printed, indicating that it is filtering the OpenJDK bundled _security providers_:

```
Provider[0x3|main|Provider.java:1252|2026-02-18 16:55:24.645]: SunJCE.putService(): SunJCE: Mac.HmacSHA1 -> com.sun.crypto.provider.HmacSHA1
aliases: [OID.1.2.840.113549.2.7, 1.2.840.113549.2.7]
attributes: {SupportedKeyFormats=RAW}

Provider[0x3|main|Provider.java:1265|2026-02-18 16:55:24.645]: The previous SunJCE.putService() call was skipped by java.security.Provider$RedHatFIPSFilter
```

### Execution of [`ssl-tests`](https://github.com/rh-openjdk/ssl-tests)

```bash
git clone https://github.com/rh-openjdk/ssl-tests && cd ssl-tests
make clean ssl-tests-build certgen_all
make ssl-tests
```

All the tests are either passing or being skipped.

<details><summary>Expand to see the results</summary>

```
IGNORED: SunJSSE/DTLS: DTLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/DTLS: DTLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/DTLS: DTLSv1.2 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/DTLS: DTLSv1.2 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/DTLS: DTLSv1.2 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/DTLS: DTLSv1.2 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/DTLS: DTLSv1.2 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
IGNORED: SunJSSE/DTLSv1.2: DTLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/DTLSv1.2: DTLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/DTLSv1.2: DTLSv1.2 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/DTLSv1.2: DTLSv1.2 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/DTLSv1.2: DTLSv1.2 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/DTLSv1.2: DTLSv1.2 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/DTLSv1.2: DTLSv1.2 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
PASSED: SunJSSE/TLS: TLSv1.3 + TLS_AES_256_GCM_SHA384
PASSED: SunJSSE/TLS: TLSv1.3 + TLS_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLS: TLSv1.3 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/TLS: TLSv1.3 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLS: TLSv1.3 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/TLS: TLSv1.3 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLS: TLSv1.3 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/TLS: TLSv1.3 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLS: TLSv1.3 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
IGNORED: SunJSSE/TLS: TLSv1.2 + TLS_AES_256_GCM_SHA384
IGNORED: SunJSSE/TLS: TLSv1.2 + TLS_AES_128_GCM_SHA256
PASSED: SunJSSE/TLS: TLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLS: TLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
PASSED: SunJSSE/TLS: TLSv1.2 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLS: TLSv1.2 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
PASSED: SunJSSE/TLS: TLSv1.2 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLS: TLSv1.2 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLS: TLSv1.2 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
PASSED: SunJSSE/Default: TLSv1.3 + TLS_AES_256_GCM_SHA384
PASSED: SunJSSE/Default: TLSv1.3 + TLS_AES_128_GCM_SHA256
IGNORED: SunJSSE/Default: TLSv1.3 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/Default: TLSv1.3 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/Default: TLSv1.3 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/Default: TLSv1.3 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/Default: TLSv1.3 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/Default: TLSv1.3 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/Default: TLSv1.3 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
IGNORED: SunJSSE/Default: TLSv1.2 + TLS_AES_256_GCM_SHA384
IGNORED: SunJSSE/Default: TLSv1.2 + TLS_AES_128_GCM_SHA256
PASSED: SunJSSE/Default: TLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/Default: TLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
PASSED: SunJSSE/Default: TLSv1.2 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/Default: TLSv1.2 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
PASSED: SunJSSE/Default: TLSv1.2 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/Default: TLSv1.2 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/Default: TLSv1.2 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
PASSED: SunJSSE/TLSv1.2: TLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLSv1.2: TLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
PASSED: SunJSSE/TLSv1.2: TLSv1.2 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLSv1.2: TLSv1.2 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
PASSED: SunJSSE/TLSv1.2: TLSv1.2 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLSv1.2: TLSv1.2 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLSv1.2: TLSv1.2 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
PASSED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_AES_256_GCM_SHA384
PASSED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
IGNORED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLSv1.3: TLSv1.3 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
IGNORED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_AES_256_GCM_SHA384
IGNORED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_AES_128_GCM_SHA256
PASSED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
PASSED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
PASSED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
PASSED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
IGNORED: SunJSSE/TLSv1.3: TLSv1.2 + TLS_EMPTY_RENEGOTIATION_INFO_SCSV
```

</details>